### PR TITLE
Adding support for data object copy

### DIFF
--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -151,6 +151,47 @@ class DataObjectManager(Manager):
             conn.send(message)
             response = conn.recv()
 
+    def copy(self, src_path, dest_path):
+        # check if dest is a collection
+        # if so append filename to it
+        if self.sess.collections.exists(dest_path):
+            filename = src_path.rsplit('/', 1)[1]
+            target_path = dest_path + '/' + filename
+        else:
+            target_path = dest_path
+
+        src = FileOpenRequest(
+            objPath=src_path,
+            createMode=0,
+            openFlags=0,
+            offset=0,
+            dataSize=0,
+            numThreads=0,
+            oprType=11,   # RENAME_DATA_OBJ
+            KeyValPair_PI=StringStringMap(),
+        )
+        dest = FileOpenRequest(
+            objPath=target_path,
+            createMode=0,
+            openFlags=0,
+            offset=0,
+            dataSize=0,
+            numThreads=0,
+            oprType=11,   # RENAME_DATA_OBJ
+            KeyValPair_PI=StringStringMap(),
+        )
+        message_body = ObjCopyRequest(
+            srcDataObjInp_PI=src,
+            destDataObjInp_PI=dest
+        )
+        message = iRODSMessage('RODS_API_REQ', msg=message_body,
+                               int_info=api_number['DATA_OBJ_COPY_AN'])
+
+        with self.sess.pool.get_connection() as conn:
+            conn.send(message)
+            response = conn.recv()
+
+
     def truncate(self, path, size):
         options = {}
         message_body = FileOpenRequest(


### PR DESCRIPTION
I just re-used the `move()` method of `DataObjectManager`, changing `api_number['DATA_OBJ_RENAME_AN']` to `api_number['DATA_OBJ_COPY_AN']`. Seems to work:

```
>>> from irods.session import iRODSSession
>>> sess = iRODSSession(host='data.iplantcollaborative.org', port=1247, user='test-cmart', password='hi github!', zone='iplant')
>>> sess.data_objects.copy("/iplant/home/test-cmart/testfile2", "/iplant/home/test-cmart/testfile")
>>> sess.data_objects.copy("/iplant/home/test-cmart/xenial-server-cloudimg-amd64-disk1.img", "/iplant/home/test-cmart/iso-copy")
>>> exit()
```

```
cmart@ipc-cmart:~$ ils -l
/iplant/home/test-cmart:
  test-cmart        0 CyVerseRes;dustyRes    313851904 2017-04-04.09:07 & iso-copy
  test-cmart        0 CyVerseRes;juniorRes            0 2017-04-04.09:03 & testfile
  test-cmart        0 CyVerseRes;dustyRes            0 2017-04-03.10:37 & testfile2
  ipc_admin         0 CyVerseRes;juniorRes    313851904 2017-04-03.10:26 & xenial-server-cloudimg-amd64-disk1.img
```

I barely know enough to be dangerous here, so hopefully someone more familiar with iRODS will look this over. :)