### PR TITLE
Use the same naming as iRODS environment variable

### DIFF
--- a/irods/account.py
+++ b/irods/account.py
@@ -1,7 +1,7 @@
 class iRODSAccount(object):
 
     def __init__(self, irods_host, irods_port, irods_user_name, irods_zone_name,
-                 irods_authentication_scheme='password',
+                 irods_authentication_scheme='native',
                  password=None, client_user=None,
                  server_dn=None, client_zone=None, **kwargs):
 

--- a/irods/connection.py
+++ b/irods/connection.py
@@ -32,8 +32,8 @@ class Connection(object):
 
         scheme = self.account.authentication_scheme
 
-        if scheme == 'password':
-            self._login_password()
+        if scheme == 'native':
+            self._login_native()
         elif scheme == 'gsi':
             self.client_ctx = None
             self._login_gsi()
@@ -270,7 +270,7 @@ class Connection(object):
         response = self.recv()
         return response.bs
 
-    def _login_password(self):
+    def _login_native(self):
 
         # authenticate
         auth_req = iRODSMessage(msg_type='RODS_API_REQ', int_info=703)


### PR DESCRIPTION
Use the same naming as iRODS environment variable irods_authentication_scheme