### PR TITLE
[#104] force open flags to client os independent values

### DIFF
--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -114,12 +114,12 @@ class DataObjectManager(Manager):
                 pass
 
         flags, seek_to_end = {
-            'r': (os.O_RDONLY, False),
-            'r+': (os.O_RDWR, False),
-            'w': (os.O_WRONLY | os.O_CREAT | os.O_TRUNC, False),
-            'w+': (os.O_RDWR | os.O_CREAT | os.O_TRUNC, False),
-            'a': (os.O_WRONLY | os.O_CREAT, True),
-            'a+': (os.O_RDWR | os.O_CREAT, True),
+            'r': (self.sess.O_RDONLY, False),
+            'r+': (self.sess.O_RDWR, False),
+            'w': (self.sess.O_WRONLY | self.sess.O_CREAT | self.sess.O_TRUNC, False),
+            'w+': (self.sess.O_RDWR | self.sess.O_CREAT | self.sess.O_TRUNC, False),
+            'a': (self.sess.O_WRONLY | self.sess.O_CREAT, True),
+            'a+': (self.sess.O_RDWR | self.sess.O_CREAT, True),
         }[mode]
         # TODO: Use seek_to_end
 

--- a/irods/session.py
+++ b/irods/session.py
@@ -31,6 +31,13 @@ class iRODSSession(object):
         self.user_groups = UserGroupManager(self)
         self.resources = ResourceManager(self)
 
+        # os module Linux constants for using in open message flags
+        self.O_RDONLY = 0
+        self.O_WRONLY = 1
+        self.O_RDWR = 2
+        self.O_CREAT = 64
+        self.O_TRUNC = 512
+
     def __enter__(self):
         return self
 

--- a/irods/session.py
+++ b/irods/session.py
@@ -31,13 +31,6 @@ class iRODSSession(object):
         self.user_groups = UserGroupManager(self)
         self.resources = ResourceManager(self)
 
-        # os module Linux constants for using in open message flags
-        self.O_RDONLY = 0
-        self.O_WRONLY = 1
-        self.O_RDWR = 2
-        self.O_CREAT = 64
-        self.O_TRUNC = 512
-
     def __enter__(self):
         return self
 


### PR DESCRIPTION
This may not be the best solution because it will be incorrect if the server has different `os.O_*` flags than those defined on Linux.

@adetorcy feel free to criticize