### PR TITLE
Lazy load resource children

### DIFF
--- a/irods/models.py
+++ b/irods/models.py
@@ -67,7 +67,7 @@ class Resource(Model):
     children = Column(String, 'R_RESC_CHILDREN', 315, min_version=(4,0,0))
     context = Column(String, 'R_RESC_CONTEXT', 316, min_version=(4,0,0))
     parent = Column(String, 'R_RESC_PARENT', 317, min_version=(4,0,0))
-    parent_context = Column(String, 'R_RESC_PARENT_CONTEXT', 318, min_version=(4,0,0))
+    parent_context = Column(String, 'R_RESC_PARENT_CONTEXT', 318, min_version=(4,2,0))
 
 
 class DataObject(Model):

--- a/irods/resource.py
+++ b/irods/resource.py
@@ -1,5 +1,4 @@
 from __future__ import absolute_import
-import sys
 from irods.models import Resource
 import six
 
@@ -33,17 +32,50 @@ class iRODSResource(object):
                     try:
                         setattr(self, attr, result[value])
                     except KeyError:
-                        # backward compatibility with pre iRODS 4
-                        sys.exc_clear()
+                        # backward compatibility with older schema versions
+                        pass
 
         self._meta = None
+
 
     @property
     def context_fields(self):
         return dict(pair.split("=") for pair in self.context.split(";"))
 
+
+    @property
+    def children(self):
+        try:
+            return self._children
+        except AttributeError:
+            # the children have not yet been resolved
+            session = self.manager.sess
+            version = session.server_version
+
+            if version >= (4,2,0):
+                # iRODS 4.2+: find parent by resource id
+                parent = self.id
+            elif version >= (4,0,0):
+                # iRODS 4.0/4.1: find parent by resource name
+                parent = self.name
+            else:
+                raise RuntimeError('Resource composition not supported')
+
+            # query for children and cache results
+            query = session.query(Resource).filter(Resource.parent == '{}'.format(parent))
+            self._children = [self.__class__(self.manager, res) for res in query]
+
+            return self._children
+
+
+    @children.setter
+    def children(self, children):
+        pass
+
+
     def __repr__(self):
         return "<iRODSResource {id} {name} {type}>".format(**vars(self))
+
 
     def remove(self, test=False):
         self.manager.remove(self.name, test)


### PR DESCRIPTION
The cause of #111 is that in irods 4.2 resources no longer list their children in the iCAT as per irods/irods#3039. A query on `Resource.children` will return `None`.

This fix addresses this by finding resources whose parent is the current resource. In addition the return value of `resource.children` has been modified for greater usability. Instead of getting a string of resource names, e.g `'ufs1{cache};ufs2{archive}'` we now get a list of actual resource objects with all their attributes, e.g:
```python
        for child in resource.children:
            print(child.name)
            print(child.id)
            print(child.type)
            print(child.location)
            print(child.parent_context)
            # etc...
```