### PR TITLE
[#114] use socket.recv_into() to speed up file download

### DIFF
--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -113,11 +113,10 @@ class iRODSDataObjectFileRaw(io.RawIOBase):
         return self.conn.seek_file(self.desc, offset, whence)
 
     def readinto(self, b):
-        contents = self.conn.read_file(self.desc, len(b))
+        contents = self.conn.read_file(self.desc, buffer=b)
         if contents is None:
             return 0
-        for i, c in enumerate(contents):
-            b[i] = c
+
         return len(contents)
 
     def write(self, b):


### PR DESCRIPTION
File downloading (in `iRODSDataObjectFileRaw.readinto()`) is changed in order to put received data directly into the intended buffer (exposing `socket.recv_into()` through `Connection` object),  instead of copying from the output of `socket.recv()`.

In my tests, this allows a speedup of some 30% on a 1GB file.