### PR TITLE
Allow input, output while reading rule from file

### DIFF
--- a/irods/rule.py
+++ b/irods/rule.py
@@ -6,19 +6,21 @@ class Rule(object):
     def __init__(self, session, rule_file=None, body='', params=None, output=''):
         self.session = session
 
+        self.params = {}
+        self.output = ''
+
         if rule_file:
             self.load(rule_file)
         else:
             self.body = '@external\n' + body
-            if params is None:
-                self.params = {}
-            else:
-                self.params = params
+
+        # overwrite params and output if received arguments
+        if params is not None:
+            self.params = params
+        if output != '':
             self.output = output
 
     def load(self, rule_file):
-        self.params = {}
-        self.output = ''
         self.body = '@external\n'
 
         # parse rule file


### PR DESCRIPTION
I'm not sure this is the intended behaviour but I have a static rule body without `INPUT` or `OUTPUT` and wish to supply this dynamically. Before this commit, it was either possible to 1) read everything from file or 2) supply everything (having to pass a body in addition to I/O).