### PR TITLE
Include resc_hier in replica information

### DIFF
--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -23,11 +23,12 @@ def irods_basename(path):
 
 class iRODSReplica(object):
 
-    def __init__(self, number, status, resource_name, path, **kwargs):
+    def __init__(self, number, status, resource_name, path, resc_hier, **kwargs):
         self.number = number
         self.status = status
         self.resource_name = resource_name
         self.path = path
+        self.resc_hier = resc_hier
         for key, value in kwargs.items():
             setattr(self, key, value)
 
@@ -61,6 +62,7 @@ class iRODSDataObject(object):
                 r[DataObject.replica_status],
                 r[DataObject.resource_name],
                 r[DataObject.path],
+                r[DataObject.resc_hier],
                 checksum=r[DataObject.checksum],
                 size=r[DataObject.size]
             ) for r in replicas]

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -1028,6 +1028,73 @@ class TestDataObjOps(unittest.TestCase):
         # delete file
         os.remove(test_file)
 
+    def test_get_data_objects(self):
+        # Can't do one step open/create with older servers
+        if self.sess.server_version <= (4, 1, 4):
+            self.skipTest('For iRODS 4.1.5 and newer')
+
+        # test vars
+        test_dir = '/tmp'
+        filename = 'get_data_objects_test_file'
+        test_file = os.path.join(test_dir, filename)
+        collection = self.coll.path
+
+        # make random 16byte binary file
+        original_size = 16
+        with open(test_file, 'wb') as f:
+            f.write(os.urandom(original_size))
+
+        # make ufs resources
+        ufs_resources = []
+        for i in range(2):
+            resource_name = 'ufs{}'.format(i)
+            resource_type = 'unixfilesystem'
+            resource_host = self.sess.host
+            resource_path = '/tmp/{}'.format(resource_name)
+            ufs_resources.append(self.sess.resources.create(
+                resource_name, resource_type, resource_host, resource_path))
+
+        # make passthru resource and add ufs1 as a child
+        passthru_resource = self.sess.resources.create('pt', 'passthru')
+        self.sess.resources.add_child(passthru_resource.name, ufs_resources[1].name)
+
+        # put file in test collection and replicate
+        obj_path = '{collection}/{filename}'.format(**locals())
+        options = {kw.DEST_RESC_NAME_KW: ufs_resources[0].name}
+        self.sess.data_objects.put(test_file, '{collection}/'.format(**locals()), **options)
+        self.sess.data_objects.replicate(obj_path, passthru_resource.name)
+
+        # ensure that replica info is populated
+        obj = self.sess.data_objects.get(obj_path)
+        for i in ["number","status","resource_name","path","resc_hier"]:
+            self.assertIsNotNone(obj.replicas[0].__getattribute__(i))
+            self.assertIsNotNone(obj.replicas[1].__getattribute__(i))
+
+        # ensure replica info is sensible
+        for i in range(2):
+            self.assertEqual(obj.replicas[i].number, i)
+            self.assertEqual(obj.replicas[i].status, '1')
+            self.assertEqual(obj.replicas[i].path.split('/')[-1], filename)
+            self.assertEqual(obj.replicas[i].resc_hier.split(';')[-1], ufs_resources[i].name)
+
+        self.assertEqual(obj.replicas[0].resource_name, ufs_resources[0].name)
+        if self.sess.server_version < (4, 2, 0):
+            self.assertEqual(obj.replicas[i].resource_name, passthru_resource.name)
+        else:
+            self.assertEqual(obj.replicas[i].resource_name, ufs_resources[1].name)
+        self.assertEqual(obj.replicas[1].resc_hier.split(';')[0], passthru_resource.name)
+
+        # remove object
+        obj.unlink(force=True)
+        # delete file
+        os.remove(test_file)
+
+        # remove resources
+        self.sess.resources.remove_child(passthru_resource.name, ufs_resources[1].name)
+        passthru_resource.remove()
+        for resource in ufs_resources:
+            resource.remove()
+
 
 if __name__ == '__main__':
     # let the tests find the parent irods lib


### PR DESCRIPTION
Finding out the full resource hierarchy is important for dealing with replicas. In the past, we had a naming scheme that allowed us to work around it, but now that naming scheme doesn't provide what we need. Including resc_hier in the replicas information allows us to do it the right way, and is hopefully useful for others