### PR TITLE
Fix CAT_STATEMENT_TABLE_FULL by auto closing queries

### DIFF
--- a/irods/exception.py
+++ b/irods/exception.py
@@ -1133,6 +1133,9 @@ class CAT_TABLE_ACCESS_DENIED(CatalogLibraryException):
 class CAT_UNKNOWN_SPECIFIC_QUERY(CatalogLibraryException):
     code = -853000
 
+class CAT_STATEMENT_TABLE_FULL(CatalogLibraryException):
+    code = -860000
+
 
 class RDSException(iRODSException):
     pass


### PR DESCRIPTION
Hello,

We ran into an issue with [a python script](https://github.com/UtrechtUniversity/irods-consistency-check/blob/master/ichk/check.py) that executes many queries:

Query methods `one`, `first` and `get_results` do not close the query, leading to a CAT_STATEMENT_TABLE_FULL error after ~50 `.first()` queries are executed in a single session.

Arguably the programmer may be made responsible for closing queries, however the implementation of e.g. `first` appears to make this impossible (the `continue_index` is inaccessible).

`get_results()` works as long as all results are handled: An early `break`, exiting the generator, leaves the query open.

---

This change automatically closes open queries after early `get_results()` generator exit, and after the first resultset of `one()` and `first()` are received.

I added a (crude) test case here:
https://gist.github.com/cjsmeele/2606317ecc6f192a7b09faa76184d874

There is a related issue in the python rule engine plugin: irods/irods#4438 , which appears to have been fixed similarly by auto-closing queries.

