### PR TITLE
Add metadata property to user and usergroup objects

### DIFF
--- a/irods/user.py
+++ b/irods/user.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 from irods.models import User, UserGroup, UserAuth
+from irods.meta import iRODSMetaCollection
 from irods.exception import NoResultFound
 
 
@@ -18,6 +19,13 @@ class iRODSUser(object):
     def dn(self):
         query = self.manager.sess.query(UserAuth.user_dn).filter(UserAuth.user_id == self.id)
         return [res[UserAuth.user_dn] for res in query]
+
+    @property
+    def metadata(self):
+        if not self._meta:
+            self._meta = iRODSMetaCollection(
+                 self.manager.sess.metadata, User, self.name)
+        return self._meta
 
     def modify(self, *args, **kwargs):
         self.manager.modify(self.name, *args, **kwargs)
@@ -47,6 +55,13 @@ class iRODSUserGroup(object):
     @property
     def members(self):
         return self.manager.getmembers(self.name)
+    
+    @property
+    def metadata(self):
+        if not self._meta:
+            self._meta = iRODSMetaCollection(
+                 self.manager.sess.metadata, User, self.name)
+        return self._meta
 
     def addmember(self, user_name, user_zone=""):
         self.manager.addmember(self.name, user_name, user_zone)


### PR DESCRIPTION
This pull request resolves #167 by adding a metadata property to user objects and usergroup objects, so metadata can be handled in the same way as with collections and data objects