### PR TITLE
[#167] Add metadata for user and usergroup objects

### DIFF
--- a/irods/test/helpers.py
+++ b/irods/test/helpers.py
@@ -124,6 +124,17 @@ def compute_sha256_digest(file_path):
     return base64.b64encode(hasher.digest()).decode()
 
 
+def remove_unused_metadata(session):
+    from irods.message import GeneralAdminRequest
+    from irods.api_number import api_number
+    message_body = GeneralAdminRequest( 'rm', 'unusedAVUs', '','','','')
+    req = iRODSMessage("RODS_API_REQ", msg = message_body,int_info=api_number['GENERAL_ADMIN_AN'])
+    with session.pool.get_connection() as conn:
+        conn.send(req)
+        response=conn.recv()
+        if (response.int_info != 0): raise RuntimeError("Error removing unused AVUs")
+
+
 @contextlib.contextmanager
 def file_backed_up(filename):
     with tempfile.NamedTemporaryFile(prefix=os.path.basename(filename)) as f:

--- a/irods/user.py
+++ b/irods/user.py
@@ -55,7 +55,7 @@ class iRODSUserGroup(object):
     @property
     def members(self):
         return self.manager.getmembers(self.name)
-    
+
     @property
     def metadata(self):
         if not self._meta:


### PR DESCRIPTION
Passed in [CI](http://172.25.14.63:8080/job/python-irodsclient-test-workflow/368/)
Incorporates evwieringen [pull request](https://github.com/irods/python-irodsclient/pull/168) with whitespace (and other) corrections, plus enhancements to the tests.