### PR TITLE
[163] add keywords to query objects

### DIFF
--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -50,7 +50,9 @@ class DataObjectManager(Manager):
 
         query = self.sess.query(DataObject)\
             .filter(DataObject.name == irods_basename(path))\
-            .filter(DataObject.collection_id == parent.id)
+            .filter(DataObject.collection_id == parent.id)\
+            .add_keyword(kw.ZONE_KW, path.split('/')[1])
+
         results = query.all() # get up to max_rows replicas
         if len(results) <= 0:
             raise ex.DataObjectDoesNotExist()

--- a/irods/query.py
+++ b/irods/query.py
@@ -36,6 +36,7 @@ class Query(object):
         self._limit = -1
         self._offset = 0
         self._continue_index = 0
+        self._keywords = {}
 
         for arg in args:
             if isinstance(arg, type) and issubclass(arg, Model):
@@ -54,6 +55,12 @@ class Query(object):
         new_q._limit = self._limit
         new_q._offset = self._offset
         new_q._continue_index = self._continue_index
+        new_q._keywords = self._keywords
+        return new_q
+
+    def add_keyword(self, keyword, value = ''):
+        new_q = self._clone()
+        new_q._keywords[keyword] = value
         return new_q
 
     def filter(self, *criteria):
@@ -138,6 +145,8 @@ class Query(object):
             for criterion in self.criteria
             if isinstance(criterion.query_key, Keyword)
         ])
+        for key in self._keywords:
+            dct[ key ] = self._keywords[key]
         return StringStringMap(dct)
 
     def _message(self):


### PR DESCRIPTION
Query objects now can utilize the builder method "add_keyword" to set keyword options on API requests.

This provides a way to direct a query to a remote (federated) zone using the `ZONE_KW` keyword.