### PR TITLE
[#135] fix queries for multiple AVUs of same name

### DIFF
--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -252,14 +252,11 @@ class _OrderedMultiMapping :
     def __len__(self):
         return len(self._keys)
     def __init__(self, list_of_keyval_tuples ):
-        self.dedup = set()
         self._keys = []
         self._values = []
         for k,v in list_of_keyval_tuples:
-            if (k,v) not in self.dedup:
-                self.dedup.add((k,v))
-                self._keys.append(k)
-                self._values.append(v)
+            self._keys.append(k)
+            self._values.append(v)
 
 
 class IntegerIntegerMap(Message):


### PR DESCRIPTION
The last fix for issue #135 was lacking in one respect, the ability to query for two AVU's with identical conditions on the AVU-name but, for instance, different conditions on the AVU-value.  This was due to unnecessary checking of duplicate in the series of filters applied to a query.  New tests are in this commit as well, and as before, the entire suite of tests passed for both Python 2 and 3.