### PR TITLE
connection caching issue

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -117,7 +117,7 @@ class Connection(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        self.release()
+        self.release(True)
 
     def release(self, destroy=False):
         self.pool.release_connection(self, destroy)

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -21,6 +21,9 @@ class Pool(object):
         with self._lock:
             try:
                 conn = self.idle.pop()
+                #release and return new connection until cache issue is cleared
+                del conn
+                conn = Connection(self, self.account)
             except KeyError:
                 conn = Connection(self, self.account)
             self.active.add(conn)


### PR DESCRIPTION
This pr fixes issue #193 . 
Each connection/socket is destroy and recreated to make sure the most up to date information is retrieve
