### PR TITLE
Multithreaded put/get

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -40,6 +40,7 @@ class Connection(object):
         self.socket = None
         self.account = account
         self._client_signature = None
+        self.shared_secret = None
         self._server_version = self._connect()
 
         scheme = self.account.authentication_scheme
@@ -249,7 +250,6 @@ class Connection(object):
         # Server responds with version
         version_msg = self.recv()
 
-        self.shared_secret = None
         if neg_result == USE_SSL:
             self.ssl_startup()
 

--- a/irods/connection.py
+++ b/irods/connection.py
@@ -162,6 +162,8 @@ class Connection(object):
         # Generate key (shared secret)
         key = os.urandom(self.account.encryption_key_size)
 
+        self.shared_secret = key
+
         # Send header-only message with client side encryption settings
         packed_header = iRODSMessage.pack_header(algo,
                                                  key_size,
@@ -247,6 +249,7 @@ class Connection(object):
         # Server responds with version
         version_msg = self.recv()
 
+        self.shared_secret = None
         if neg_result == USE_SSL:
             self.ssl_startup()
 

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -201,7 +201,7 @@ class DataObjectManager(Manager):
                         crypt = Encryption(conn)
 
                     while True:
-                        opr, flags, _, size = recv_xfer_header(sock)
+                        opr, _, offset, size = recv_xfer_header(sock)
                         if opr == self.DONE_OPR:
                             break
 

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -201,7 +201,7 @@ class DataObjectManager(Manager):
                         crypt = Encryption(conn)
 
                     while True:
-                        opr, flags, offset, size = recv_xfer_header(sock)
+                        opr, flags, _, size = recv_xfer_header(sock)
                         if opr == self.DONE_OPR:
                             break
 
@@ -303,7 +303,7 @@ class DataObjectManager(Manager):
             # create local file
             pass
 
-        for i in range(nt):
+        for _ in range(nt):
             sock = connect_to_portal(host, port, cookie)
             fut = executor.submit(recv_task, sock, local_path, conn,
                                   task_count)
@@ -361,7 +361,7 @@ class DataObjectManager(Manager):
                         crypt = Encryption(conn)
 
                     while True:
-                        opr, _flags, offset, size = recv_xfer_header(sock)
+                        opr, _, offset, size = recv_xfer_header(sock)
 
                         if opr == self.DONE_OPR:
                             break
@@ -402,7 +402,7 @@ class DataObjectManager(Manager):
                                        int_info=api_number['OPR_COMPLETE_AN'])
 
                 conn.send(message)
-                _resp = conn.recv()
+                conn.recv()
                 conn.release()
 
                 replicate()
@@ -429,10 +429,9 @@ class DataObjectManager(Manager):
         if kw.OPR_TYPE_KW not in options:
             options[kw.OPR_TYPE_KW] = 1 # PUT_OPR
 
-        _response, message, conn = self._open_request(irods_path,
-                                                      'DATA_OBJ_PUT_AN',
-                                                      'w', local_size,
-                                                      **options)
+        _, message, conn = self._open_request(irods_path,
+                                              'DATA_OBJ_PUT_AN', 'w',
+                                              local_size, **options)
 
         use_encryption = conn.shared_secret is not None
 
@@ -466,7 +465,7 @@ class DataObjectManager(Manager):
 
             task_count = LockCounter(nt)
 
-            for _i in range(nt):
+            for _ in range(nt):
                 sock = connect_to_portal(host, port, cookie)
                 fut = executor.submit(send_task, sock, local_path, conn,
                                       task_count)

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -2,10 +2,8 @@ from __future__ import absolute_import
 import os
 import io
 import socket
-import ssl
 import struct
 import threading
-import time
 from concurrent.futures import ThreadPoolExecutor
 
 import M2Crypto
@@ -421,14 +419,13 @@ class DataObjectManager(Manager):
         if kw.OPR_TYPE_KW not in options:
             options[kw.OPR_TYPE_KW] = 1 # PUT_OPR
 
-        # for now, can't handle ssl multithreaded operation
-        with self.sess.pool.get_connection() as conn:
-            use_encryption = isinstance(conn.socket, ssl.SSLSocket)
-
         response, message, conn = self._open_request(irods_path,
                                                      'DATA_OBJ_PUT_AN',
                                                      'w', local_size,
                                                      **options)
+
+        use_encryption = conn.shared_secret is not None
+
         desc = message.l1descInx
         nt = message.numThreads
         if nt <= 0:

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -267,7 +267,8 @@ class DataObjectManager(Manager):
                                         local_path, response, conn,
                                         progress_cb)]
 
-            write_from_response(local_path, response, conn)
+            write_from_response(irods_path, local_path, response, conn,
+                                progress_cb)
             return []
 
         futs = []

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -72,10 +72,16 @@ def recv_xfer_header(sock):
 
     fmt = '!iiqq'
     size = struct.calcsize(fmt)
-    buf = bytearray(b'\0' * size)
+    buf = bytearray(size)
     recv_size = sock.recv_into(buf, size)
     if recv_size != size:
-        raise ex.SYS_COPY_LEN_ERR
+        try:
+            # try to unpack only opr type instead of whole header
+            opr = struct.unpack('!i', buf[0:recv_size])[0]
+            return (opr, 0, 0, 0)
+        except:
+            # raise error if unpack failed
+            raise ex.SYS_COPY_LEN_ERR
 
     u = struct.unpack(fmt, buf)
     return u
@@ -88,7 +94,7 @@ class Encryption:
 
         self.ifmt = 'i'
         self.isize = struct.calcsize(self.ifmt)
-        self.ibuf = bytearray(b'\0' * self.isize)
+        self.ibuf = bytearray(self.isize)
 
     def recv_int(self, sock):
         recv_size = sock.recv_into(self.ibuf, self.isize)

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -28,7 +28,7 @@ def _recv_message_in_len(sock, size):
         except (AttributeError, ValueError):
             buf = sock.recv(size_left)
         except OSError as e:
-            #skip only Windows error 10045 
+            #skip only Windows error 10045
             if getattr(e, 'winerror', 0) != 10045:
                 raise
             buf = sock.recv(size_left)
@@ -50,7 +50,7 @@ def _recv_message_into(sock, buffer, size):
         except (AttributeError, ValueError):
             rsize = sock.recv_into(mv[index:], size_left)
         except OSError as e:
-            #skip only Windows error 10045 
+            #skip only Windows error 10045
             if getattr(e, 'winerror', 0) != 10045:
                 raise
             rsize = sock.recv_into(mv[index:], size_left)
@@ -171,6 +171,12 @@ class iRODSMessage(object):
         msg.unpack(ET.fromstring(self.msg))
         return msg
 
+
+# define INT_PI "int myInt;"
+
+class OprComplete(Message):
+    _name = 'INT_PI'
+    myInt = IntegerProperty()
 
 #define CS_NEG_PI "int status; str result[MAX_NAME_LEN];"
 class ClientServerNegotiation(Message):
@@ -375,6 +381,30 @@ class OpenedDataObjRequest(Message):
     offset = LongProperty()
     bytesWritten = LongProperty()
     KeyValPair_PI = SubmessageProperty(StringStringMap)
+
+#define PortList_PI "int portNum; int cookie; int sock; int windowSize;
+# str hostAddr[LONG_NAME_LEN];"
+
+
+class PortList(Message):
+    _name = 'PortList_PI'
+    portNum = IntegerProperty()
+    cookie = IntegerProperty()
+    sock = IntegerProperty()
+    windowSize = IntegerProperty()
+    hostAddr = StringProperty()
+
+# define PortalOprOut_PI "int status; int l1descInx; int numThreads;
+# str chksum[NAME_LEN]; struct PortList_PI;"
+
+
+class PortalOprResponse(Message):
+    _name = 'PortalOprOut_PI'
+    status = IntegerProperty()
+    l1descInx = IntegerProperty()
+    numThreads = IntegerProperty()
+    chksum = StringProperty()
+    PortList_PI = SubmessageProperty(PortList)
 
 # define fileLseekOut_PI "double offset;"
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='python-irodsclient',
       install_requires=[
                         'six>=1.10.0',
                         'PrettyTable>=0.7.2',
-                        'xmlrunner>=1.7.7'
+                        'xmlrunner>=1.7.7',
+                        'M2Crypto>=0.35.2',
                         ]
       )


### PR DESCRIPTION
Implements parallel protocol for put and get operations.

`DataObjectManager` object has new methods to perform parallel transfers: `download_parallel()` and `put_parallel()`.

Remarks:
- uses [ThreadPoolExecutor](https://docs.python.org/3/library/concurrent.futures.html#threadpoolexecutor) to handle parallel transfers.
- adds a dependency on module [M2Crypto](https://pypi.org/project/M2Crypto/) to implement EVP encryption on transfer channels
- store `shared_secret` (from SSL socket creation) in Connection object in case of encrypted communications