### PR TITLE
resc_hier backward compatibility

### DIFF
--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -62,7 +62,7 @@ class iRODSDataObject(object):
                 r[DataObject.replica_status],
                 r[DataObject.resource_name],
                 r[DataObject.path],
-                r[DataObject.resc_hier],
+                r.get(DataObject.resc_hier, None),
                 checksum=r[DataObject.checksum],
                 size=r[DataObject.size]
             ) for r in replicas]


### PR DESCRIPTION
`DataObject.resc_hier` is absent in servers before iRODS v4. This PR is a workaround to restore backward compatibility with iRODS v3 servers.