### PR TITLE
[211] set and report application name to server

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -37,7 +37,7 @@ class Connection(object):
 
     DISALLOWING_PAM_PLAINTEXT = True
 
-    def __init__(self, pool, account):
+    def __init__(self, pool, account ):
 
         self.pool = pool
         self.socket = None
@@ -196,9 +196,11 @@ class Connection(object):
                 "{}:{}".format(*address))
 
         self.socket = s
+
         main_message = StartupPack(
             (self.account.proxy_user, self.account.proxy_zone),
-            (self.account.client_user, self.account.client_zone)
+            (self.account.client_user, self.account.client_zone),
+            self.pool.client_name
         )
 
         # No client-server negotiation

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -188,7 +188,7 @@ class ClientServerNegotiation(Message):
 class StartupPack(Message):
     _name = 'StartupPack_PI'
 
-    def __init__(self, proxy_user, client_user, client_name):
+    def __init__(self, proxy_user, client_user, client_name = ''):
         super(StartupPack, self).__init__()
         if proxy_user and client_user:
             self.irodsProt = 1

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -188,7 +188,7 @@ class ClientServerNegotiation(Message):
 class StartupPack(Message):
     _name = 'StartupPack_PI'
 
-    def __init__(self, proxy_user, client_user):
+    def __init__(self, proxy_user, client_user, client_name):
         super(StartupPack, self).__init__()
         if proxy_user and client_user:
             self.irodsProt = 1
@@ -197,7 +197,7 @@ class StartupPack(Message):
             self.clientUser, self.clientRcatZone = client_user
             self.relVersion = "rods{}.{}.{}".format(*IRODS_VERSION)
             self.apiVersion = "{3}".format(*IRODS_VERSION)
-            self.option = ""
+            self.option = client_name
 
     irodsProt = IntegerProperty()
     reconnFlag = IntegerProperty()

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -14,13 +14,18 @@ DEFAULT_CLIENT_NAME='python-irodsclient'
 
 class Pool(object):
 
-    def __init__(self, account, name = ''):
+    def __init__(self, account, client_name = ''):
+        '''
+        Pool( account , client_name='' )
+        Create an iRODS connection pool; 'account' is an irods.account.iRODSAccount instance
+        and 'client_name' specifies an application name as it should appear in an 'ips' listing.
+        '''
         self.account = account
         self._lock = threading.RLock()
         self.active = set()
         self.idle = set()
         self.connection_timeout = DEFAULT_CONNECTION_TIMEOUT
-        self.client_name = (name  or  os.environ.get('spOption','')  or  DEFAULT_CLIENT_NAME)
+        self.client_name = (client_name  or  os.environ.get('spOption','')  or  DEFAULT_CLIENT_NAME)
 
     def get_connection(self):
         with self._lock:

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -32,8 +32,7 @@ class Pool(object):
             try:
                 conn = self.idle.pop()
             except KeyError:
-                conn = Connection(self, self.account, #client_name =  self.name
-                )
+                conn = Connection(self, self.account)
             self.active.add(conn)
         logger.debug('num active: {}'.format(len(self.active)))
         return conn

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import logging
 import threading
+import os
 
 from irods import DEFAULT_CONNECTION_TIMEOUT
 from irods.connection import Connection
@@ -8,21 +9,27 @@ from irods.connection import Connection
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_CLIENT_NAME='python-irodsclient'
+
+
 class Pool(object):
 
-    def __init__(self, account):
+    def __init__(self, account, name = ''):
         self.account = account
         self._lock = threading.RLock()
         self.active = set()
         self.idle = set()
         self.connection_timeout = DEFAULT_CONNECTION_TIMEOUT
+        self.client_name = (name  or  os.environ.get('spOption','')  or  DEFAULT_CLIENT_NAME)
+        #print "pool name = {.name}".format(self)
 
     def get_connection(self):
         with self._lock:
             try:
                 conn = self.idle.pop()
             except KeyError:
-                conn = Connection(self, self.account)
+                conn = Connection(self, self.account, #client_name =  self.name
+                )
             self.active.add(conn)
         logger.debug('num active: {}'.format(len(self.active)))
         return conn

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -21,7 +21,6 @@ class Pool(object):
         self.idle = set()
         self.connection_timeout = DEFAULT_CONNECTION_TIMEOUT
         self.client_name = (name  or  os.environ.get('spOption','')  or  DEFAULT_CLIENT_NAME)
-        #print "pool name = {.name}".format(self)
 
     def get_connection(self):
         with self._lock:

--- a/irods/session.py
+++ b/irods/session.py
@@ -97,7 +97,7 @@ class iRODSSession(object):
 
     def configure(self, **kwargs):
         account = self._configure_account(**kwargs)
-        self.pool = Pool(account)
+        self.pool = Pool(account, name = kwargs.pop('name',''))
 
     def query(self, *args):
         return Query(self, *args)

--- a/irods/session.py
+++ b/irods/session.py
@@ -97,7 +97,7 @@ class iRODSSession(object):
 
     def configure(self, **kwargs):
         account = self._configure_account(**kwargs)
-        self.pool = Pool(account, name = kwargs.pop('name',''))
+        self.pool = Pool(account, client_name = kwargs.pop('name',''))
 
     def query(self, *args):
         return Query(self, *args)


### PR DESCRIPTION
The following will display  "myApp" as the application name to the iRODS server, and you can see this via the  `ips` command.
If the `name` keyword is not supplied for iRODSSession(...), the  contents of the `spOption` environment variable or the default app name of "python-irodsclient" will be assigned, in that order of preference.
```
import contextlib
import time
import os
from irods.session import iRODSSession

@contextlib.contextmanager
def session(name_):
    try:
        env_file = os.environ['IRODS_ENVIRONMENT_FILE']
    except KeyError:
        env_file = os.path.expanduser('~/.irods/irods_environment.json')
    session = iRODSSession(irods_env_file=env_file, name = name_)   # <<< specify the app name here
    try:
        yield session
    finally:
        session.cleanup()
        print "cleanup"

if __name__ == '__main__':
    with session("myApp") as s:
        s.collections.get('/tempZone/home/alissa')
        time.sleep(15.0)
```
