### PR TITLE
[211] set and report application name to server 

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -196,9 +196,11 @@ class Connection(object):
                 "{}:{}".format(*address))
 
         self.socket = s
+
         main_message = StartupPack(
             (self.account.proxy_user, self.account.proxy_zone),
-            (self.account.client_user, self.account.client_zone)
+            (self.account.client_user, self.account.client_zone),
+            self.pool.application_name
         )
 
         # No client-server negotiation

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -188,7 +188,7 @@ class ClientServerNegotiation(Message):
 class StartupPack(Message):
     _name = 'StartupPack_PI'
 
-    def __init__(self, proxy_user, client_user):
+    def __init__(self, proxy_user, client_user, application_name = ''):
         super(StartupPack, self).__init__()
         if proxy_user and client_user:
             self.irodsProt = 1
@@ -197,7 +197,7 @@ class StartupPack(Message):
             self.clientUser, self.clientRcatZone = client_user
             self.relVersion = "rods{}.{}.{}".format(*IRODS_VERSION)
             self.apiVersion = "{3}".format(*IRODS_VERSION)
-            self.option = ""
+            self.option = application_name
 
     irodsProt = IntegerProperty()
     reconnFlag = IntegerProperty()

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import logging
 import threading
+import os
 
 from irods import DEFAULT_CONNECTION_TIMEOUT
 from irods.connection import Connection
@@ -8,14 +9,25 @@ from irods.connection import Connection
 logger = logging.getLogger(__name__)
 
 
+DEFAULT_APPLICATION_NAME='python-irodsclient'
+
+
 class Pool(object):
 
-    def __init__(self, account):
+    def __init__(self, account, application_name = ''):
+        '''
+        Pool( account , application_name='' )
+        Create an iRODS connection pool; 'account' is an irods.account.iRODSAccount instance and
+        'application_name' specifies the application name as it should appear in an 'ips' listing.
+        '''
         self.account = account
         self._lock = threading.RLock()
         self.active = set()
         self.idle = set()
         self.connection_timeout = DEFAULT_CONNECTION_TIMEOUT
+        self.application_name = ( os.environ.get('spOption','') or
+                                  application_name or
+                                  DEFAULT_APPLICATION_NAME )
 
     def get_connection(self):
         with self._lock:

--- a/irods/session.py
+++ b/irods/session.py
@@ -97,7 +97,7 @@ class iRODSSession(object):
 
     def configure(self, **kwargs):
         account = self._configure_account(**kwargs)
-        self.pool = Pool(account)
+        self.pool = Pool(account, application_name = kwargs.pop('application_name',''))
 
     def query(self, *args):
         return Query(self, *args)

--- a/irods/test/login_auth_test.py
+++ b/irods/test/login_auth_test.py
@@ -12,11 +12,13 @@ import irods.test.helpers as helpers
 from irods.connection import Connection
 from irods.session import iRODSSession
 from irods.rule import Rule
+from irods.models import User
 from socket import gethostname
 from irods.password_obfuscation import (encode as pw_encode)
 from irods.connection import PlainTextPAMPasswordError
 import contextlib
 from re import (compile as regex,_pattern_type as regex_type)
+
 
 def json_file_update(fname,keys_to_delete=(),**kw):
     j = json.load(open(fname,'r'))
@@ -78,19 +80,29 @@ def pam_password_in_plaintext(allow=True):
     finally:
         Connection.DISALLOWING_PAM_PLAINTEXT = saved
 
-class TestLogins(unittest.TestCase):
 
-    UserName = 'alissa'
+class TestLogins(unittest.TestCase):
+    '''
+    This is due to be moved into Jenkins CI along core and other iRODS tests.
+    Until  then, for these tests to run successfully, we require:
+      1. First run ./setupssl.py (sets up SSL keys etc. in /etc/irods/ssl)
+      2. Add & override configuration entries in /var/lib/irods/irods_environment
+         Per https://slides.com/irods/ugm2018-ssl-and-pam-configuration#/3/7
+      3. Create rodsuser alissa and corresponding unix user with the appropriate
+         passwords as below.
+    '''
+
+    test_rods_user = 'alissa'
 
     user_auth_envs = {
         '.irods.pam': {
-            'USER':     UserName,
-            'PASSWORD': 'test123',
+            'USER':     test_rods_user,
+            'PASSWORD': 'test123', # UNIX pw
             'AUTH':     'pam'
         },
         '.irods.native': {
-            'USER':     UserName,
-            'PASSWORD': 'apass',
+            'USER':     test_rods_user,
+            'PASSWORD': 'apass',   # iRODS pw
             'AUTH':     'native'
         }
     }
@@ -133,7 +145,7 @@ class TestLogins(unittest.TestCase):
                #elif lookup['AUTH'] == 'XXXXXX': # TODO: insert other authentication schemes here
                 elif lookup['AUTH'] in ('native', '',None):
                     scrambled_pw = pw_encode( lookup['PASSWORD'] )
-                cl_env = client_env_from_server_env(cls.UserName)
+                cl_env = client_env_from_server_env(cls.test_rods_user)
                 if lookup.get('AUTH',None) is not None:     # - specify auth scheme only if given
                     cl_env['irods_authentication_scheme'] = lookup['AUTH']
                 dirbase = os.path.join(os.environ['HOME'],dirname)
@@ -171,25 +183,25 @@ class TestLogins(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.admin = helpers.make_session()
-        cls.server_ssl_setting = cls.get_server_ssl_negotiation( cls.admin )
-        cls.envdirs = cls.create_env_dirs()
-        if not cls.envdirs:
-            raise RuntimeError('Could not create one or more client environments')
-
+        if cls.test_rods_user in (row[User.name] for row in cls.admin.query(User.name)):
+            cls.server_ssl_setting = cls.get_server_ssl_negotiation( cls.admin )
+            cls.envdirs = cls.create_env_dirs()
+            if not cls.envdirs:
+                raise RuntimeError('Could not create one or more client environments')
 
     @classmethod
     def tearDownClass(cls):
-        for envdir in cls.envdirs:
+        for envdir in getattr(cls, 'envdirs', []):
             shutil.rmtree(envdir, ignore_errors=True)
         cls.admin.cleanup()
 
-#   def setUp(self):
-#       # - placeholder for per-test setup
-#       super(TestLogins,self).setUp()
+    def setUp(self):
+        if not getattr(self, 'envdirs', []):
+            self.skipTest('The test_rods_user "{}" does not exist'.format(self.test_rods_user))
+        super(TestLogins,self).setUp()
 
-#   def tearDown(self):
-#       # - placeholder for per-test teardown
-#       super(TestLogins,self).tearDown()
+    def tearDown(self):
+        super(TestLogins,self).tearDown()
 
     def validate_session(self, session, verbose=False, **options):
         
@@ -198,7 +210,7 @@ class TestLogins(unittest.TestCase):
         self.assertTrue(session.collections.get(home_coll).path == home_coll)
         if verbose: print(home_coll)
         # - check user is as expected
-        self.assertEqual( session.username, self.UserName )
+        self.assertEqual( session.username, self.test_rods_user )
         # - check socket type (normal vs SSL) against whether ssl requested
         use_ssl = options.pop('ssl',None)
         if use_ssl is not None:


### PR DESCRIPTION
The below example client would report  "myApp" as its **application name** to the iRODS server, and you can see this
via the  `ips` command while the example is running. If the `name` keyword is not supplied for iRODSSession(...), the  contents of the `spOption` environment variable or the default app name of "python-irodsclient" will be assigned, currently with that order of override, though that is subject to change.

```
import time
import os
from irods.session import iRODSSession

if __name__ == '__main__':
    try:
        env_file = os.environ['IRODS_ENVIRONMENT_FILE']
    except KeyError:
        env_file = os.path.expanduser('~/.irods/irods_environment.json')

    with iRODSSession (irods_env_file = env_file, application_name = "myApp") as session:
        session.collections.get('/{0.zone}/home/{0.username}'.format(session))
        time.sleep(15.0)
``` 
