### PR TITLE
[216] capitalize -C,-R object types in XML_PROT

### DIFF
--- a/irods/manager/metadata_manager.py
+++ b/irods/manager/metadata_manager.py
@@ -18,8 +18,8 @@ class MetadataManager(Manager):
     def _model_class_to_resource_type(model_cls):
         return {
             DataObject: 'd',
-            Collection: 'c',
-            Resource: 'r',
+            Collection: 'C',
+            Resource: 'R',
             User: 'u',
         }[model_cls]
 
@@ -27,8 +27,8 @@ class MetadataManager(Manager):
         resource_type = self._model_class_to_resource_type(model_cls)
         model = {
             'd': DataObjectMeta,
-            'c': CollectionMeta,
-            'r': ResourceMeta,
+            'C': CollectionMeta,
+            'R': ResourceMeta,
             'u': UserMeta
         }[resource_type]
         conditions = {
@@ -36,8 +36,8 @@ class MetadataManager(Manager):
                 Collection.name == dirname(path),
                 DataObject.name == basename(path)
             ],
-            'c': [Collection.name == path],
-            'r': [Resource.name == path],
+            'C': [Collection.name == path],
+            'R': [Resource.name == path],
             'u': [User.name == path]
         }[resource_type]
         results = self.sess.query(model.id, model.name, model.value, model.units)\


### PR DESCRIPTION
Correcting #216 
The incorrect case was being sent over the socket API, ie  "-c" for "-C" to mean a collection, etc. This commit addresses it, and has been tested (fully passing) under Python 2.7 and 3.6