### PR TITLE
When getting a connection, last_used_time is checked. If its more than…

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -6,6 +6,7 @@ import hashlib
 import six
 import os
 import ssl
+import datetime
 
 
 from irods.message import (
@@ -56,6 +57,7 @@ class Connection(object):
             self._login_pam()
         else:
             raise ValueError("Unknown authentication scheme %s" % scheme)
+        self.last_used_time = datetime.datetime.now()
 
     @property
     def server_version(self):

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+import datetime
 import logging
 import threading
 import os
@@ -9,12 +10,12 @@ from irods.connection import Connection
 logger = logging.getLogger(__name__)
 
 
-DEFAULT_APPLICATION_NAME='python-irodsclient'
+DEFAULT_APPLICATION_NAME = 'python-irodsclient'
 
 
 class Pool(object):
 
-    def __init__(self, account, application_name = ''):
+    def __init__(self, account, application_name='', connection_refresh_time=-1):
         '''
         Pool( account , application_name='' )
         Create an iRODS connection pool; 'account' is an irods.account.iRODSAccount instance and
@@ -29,12 +30,29 @@ class Pool(object):
                                   application_name or
                                   DEFAULT_APPLICATION_NAME )
 
+        if connection_refresh_time > 0:
+            self.refresh_connection = True
+            self.connection_refresh_time = connection_refresh_time
+        else:
+            self.refresh_connection = False
+            self.connection_refresh_time = None
+
     def get_connection(self):
         with self._lock:
             try:
                 conn = self.idle.pop()
+
+                curr_time = datetime.datetime.now()
+                # If 'refresh_connection' flag is True and the connection was
+                # last used more than 'connection_refresh_time' seconds ago,
+                # release the connection (as its stale) and create a new one
+                if self.refresh_connection and (curr_time - conn.last_used_time).total_seconds() > self.connection_refresh_time:
+                    logger.debug('Connection has been idle more than {} seconds. Releasing the connection and creating a new one.'.format(self.connection_refresh_time))
+                    self.release_connection(conn, True)
+                    conn = Connection(self, self.account)
             except KeyError:
                 conn = Connection(self, self.account)
+
             self.active.add(conn)
         logger.debug('num active: {}'.format(len(self.active)))
         return conn
@@ -44,6 +62,9 @@ class Pool(object):
             if conn in self.active:
                 self.active.remove(conn)
                 if not destroy:
+                    # If 'refresh_connection' flag is True, update connection's 'last_used_time'
+                    if self.refresh_connection:
+                        conn.last_used_time = datetime.datetime.now()
                     self.idle.add(conn)
             elif conn in self.idle and destroy:
                 self.idle.remove(conn)

--- a/irods/test/pool_test.py
+++ b/irods/test/pool_test.py
@@ -1,15 +1,18 @@
 #! /usr/bin/env python
 from __future__ import absolute_import
+import datetime
 import os
 import sys
+import time
 import unittest
 import irods.test.helpers as helpers
+
 
 
 class TestPool(unittest.TestCase):
 
     def setUp(self):
-        self.sess = helpers.make_session()
+        self.sess = helpers.make_session(irods_env_file="./test-data/irods_environment.json")
 
     def tearDown(self):
         '''Close connections
@@ -17,7 +20,7 @@ class TestPool(unittest.TestCase):
         self.sess.cleanup()
 
     def test_release_connection(self):
-        with self.sess.pool.get_connection() as conn:
+        with self.sess.pool.get_connection():
             self.assertEqual(1, len(self.sess.pool.active))
             self.assertEqual(0, len(self.sess.pool.idle))
 
@@ -34,7 +37,7 @@ class TestPool(unittest.TestCase):
         self.assertEqual(0, len(self.sess.pool.idle))
 
     def test_destroy_idle(self):
-        with self.sess.pool.get_connection() as conn:
+        with self.sess.pool.get_connection():
             self.assertEqual(1, len(self.sess.pool.active))
             self.assertEqual(0, len(self.sess.pool.idle))
 
@@ -58,6 +61,150 @@ class TestPool(unittest.TestCase):
         self.assertEqual(0, len(self.sess.pool.active))
         self.assertEqual(0, len(self.sess.pool.idle))
 
+    def test_connection_last_used_time(self):
+        # Get a connection and record its object ID and last_used_time
+        # Release the connection (goes from active to idle queue)
+        # Again, get a connection. Should get the same connection back.
+        # I.e., the object IDs should match. However, the new connection
+        # should have a more recent 'last_used_time'
+        conn_obj_id_1 = None
+        conn_obj_id_2 = None
+        last_used_time_1 = None
+        last_used_time_2 = None
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_1 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_1 = conn.last_used_time
+            self.assertTrue(curr_time >= last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(1, len(self.sess.pool.idle))
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_2 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_2 = conn.last_used_time
+            self.assertEqual(conn_obj_id_1, conn_obj_id_2)
+            self.assertTrue(curr_time >= last_used_time_2)
+            self.assertTrue(last_used_time_2 >= last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(1, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn, True)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+    def test_refresh_connection(self):
+        # Set 'irods_connection_refresh_time' to '3' (in seconds) in
+        # ~/.irods/irods_environment.json file. This means any connection
+        # that is not used more than 3 seconds will be dropped and
+        # a new connection is created/returned. This is to avoid
+        # issue with idle connections that are dropped.
+        conn_obj_id_1 = None
+        conn_obj_id_2 = None
+        last_used_time_1 = None
+        last_used_time_2 = None
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_1 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_1 = conn.last_used_time
+            self.assertTrue(curr_time >= last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(1, len(self.sess.pool.idle))
+
+        # Wait more than 'irods_connection_refresh_time' seconds,
+        # which is set to 3. Connection object should have a different
+        # object ID (as a new connection is created)
+        time.sleep(5)
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_2 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_2 = conn.last_used_time
+            self.assertTrue(curr_time >= last_used_time_2)
+            self.assertNotEqual(conn_obj_id_1, conn_obj_id_2)
+            self.assertTrue(last_used_time_2 > last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn, True)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+    def test_no_refresh_connection(self):
+        # Set 'irods_connection_refresh_time' to '3' (in seconds) in
+        # ~/.irods/irods_environment.json file. This means any connection
+        # that is not used more than 3 seconds will be dropped and
+        # a new connection is created/returned. This is to avoid
+        # issue with idle connections that are dropped.
+        conn_obj_id_1 = None
+        conn_obj_id_2 = None
+        last_used_time_1 = None
+        last_used_time_2 = None
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_1 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_1 = conn.last_used_time
+            self.assertTrue(curr_time >= last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(1, len(self.sess.pool.idle))
+
+        # Wait less than 'irods_connection_refresh_time' seconds,
+        # which is set to 3. Connection object should have the same
+        # object ID (as idle time is less than 'irods_connection_refresh_time')
+        time.sleep(1)
+
+        with self.sess.pool.get_connection() as conn:
+            conn_obj_id_2 = id(conn)
+            curr_time = datetime.datetime.now()
+            last_used_time_2 = conn.last_used_time
+            self.assertTrue(curr_time >= last_used_time_2)
+            self.assertEqual(conn_obj_id_1, conn_obj_id_2)
+            self.assertTrue(last_used_time_2 >= last_used_time_1)
+            self.assertEqual(1, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+            self.sess.pool.release_connection(conn, True)
+            self.assertEqual(0, len(self.sess.pool.active))
+            self.assertEqual(0, len(self.sess.pool.idle))
+
+    def test_get_connection_refresh_time_no_env_file_input_param(self):
+        connection_refresh_time = self.sess.get_connection_refresh_time(first_name="Magic", last_name="Johnson")
+        self.assertEqual(connection_refresh_time, -1)
+
+    def test_get_connection_refresh_time_none_existant_env_file(self):
+        connection_refresh_time = self.sess.get_connection_refresh_time(irods_env_file="./test-data/irods_environment_non_existant.json")
+        self.assertEqual(connection_refresh_time, -1)
+
+    def test_get_connection_refresh_time_no_connection_refresh_field(self):
+        connection_refresh_time = self.sess.get_connection_refresh_time(irods_env_file="./test-data/irods_environment_no_refresh_field.json")
+        self.assertEqual(connection_refresh_time, -1)
+
+    def test_get_connection_refresh_time_negative_connection_refresh_field(self):
+        connection_refresh_time = self.sess.get_connection_refresh_time(irods_env_file="./test-data/irods_environment_negative_refresh_field.json")
+        self.assertEqual(connection_refresh_time, -1)
+
+    def test_get_connection_refresh_time(self):
+        connection_refresh_time = self.sess.get_connection_refresh_time(irods_env_file="./test-data/irods_environment.json")
+        self.assertEqual(connection_refresh_time, 3)
 
 if __name__ == '__main__':
     # let the tests find the parent irods lib

--- a/irods/test/test-data/irods_environment.json
+++ b/irods/test/test-data/irods_environment.json
@@ -1,0 +1,7 @@
+{
+    "irods_host": "127.0.0.1",
+    "irods_port": "1247",
+    "irods_user_name": "rods",
+    "irods_zone_name": "tempZone",
+    "irods_connection_refresh_time": "3"
+}

--- a/irods/test/test-data/irods_environment_negative_refresh_field.json
+++ b/irods/test/test-data/irods_environment_negative_refresh_field.json
@@ -1,0 +1,7 @@
+{
+    "irods_host": "127.0.0.1",
+    "irods_port": "1247",
+    "irods_user_name": "rods",
+    "irods_zone_name": "tempZone",
+    "irods_connection_refresh_time": "-3"
+}

--- a/irods/test/test-data/irods_environment_no_refresh_field.json
+++ b/irods/test/test-data/irods_environment_no_refresh_field.json
@@ -1,0 +1,6 @@
+{
+    "irods_host": "127.0.0.1",
+    "irods_port": "1247",
+    "irods_user_name": "rods",
+    "irods_zone_name": "tempZone"
+}


### PR DESCRIPTION
… a specific value (configurable), connection is considered stale, it is dropped and a new connection is created. This is to address the issue with dropped stale connections.