### PR TITLE
Use connection create time (not last used time) to decide whether a connection needs to be re-created

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -57,7 +57,8 @@ class Connection(object):
             self._login_pam()
         else:
             raise ValueError("Unknown authentication scheme %s" % scheme)
-        self.last_used_time = datetime.datetime.now()
+        self.create_time = datetime.datetime.now()
+        self.last_used_time = self.create_time
 
     @property
     def server_version(self):

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -44,28 +44,37 @@ class Pool(object):
 
                 curr_time = datetime.datetime.now()
                 # If 'refresh_connection' flag is True and the connection was
-                # last used more than 'connection_refresh_time' seconds ago,
+                # created more than 'connection_refresh_time' seconds ago,
                 # release the connection (as its stale) and create a new one
-                if self.refresh_connection and (curr_time - conn.last_used_time).total_seconds() > self.connection_refresh_time:
-                    logger.debug('Connection has been idle more than {} seconds. Releasing the connection and creating a new one.'.format(self.connection_refresh_time))
+                if self.refresh_connection and (curr_time - conn.create_time).total_seconds() > self.connection_refresh_time:
+                    logger.debug('Connection with id {} was created more than {} seconds ago. Releasing the connection and creating a new one.'.format(id(conn), self.connection_refresh_time))
                     self.release_connection(conn, True)
                     conn = Connection(self, self.account)
+                    logger.debug("Created new connection with id: {}".format(id(conn)))
             except KeyError:
                 conn = Connection(self, self.account)
+                logger.debug("No connection found in idle set. Created a new connection with id: {}".format(id(conn)))
 
             self.active.add(conn)
+            logger.debug("Adding connection with id {} to active set".format(id(conn)))
+
         logger.debug('num active: {}'.format(len(self.active)))
+        logger.debug('num idle: {}'.format(len(self.idle)))
         return conn
 
     def release_connection(self, conn, destroy=False):
         with self._lock:
             if conn in self.active:
                 self.active.remove(conn)
+                logger.debug("Removed connection with id: {} from active set".format(id(conn)))
                 if not destroy:
                     # If 'refresh_connection' flag is True, update connection's 'last_used_time'
                     if self.refresh_connection:
                         conn.last_used_time = datetime.datetime.now()
                     self.idle.add(conn)
+                    logger.debug("Added connection with id: {} to idle set".format(id(conn)))
             elif conn in self.idle and destroy:
+                logger.debug("Destroyed connection with id: {}".format(id(conn)))
                 self.idle.remove(conn)
+        logger.debug('num active: {}'.format(len(self.active)))
         logger.debug('num idle: {}'.format(len(self.idle)))

--- a/irods/session.py
+++ b/irods/session.py
@@ -99,6 +99,7 @@ class iRODSSession(object):
     def configure(self, **kwargs):
         account = self._configure_account(**kwargs)
         connection_refresh_time = self.get_connection_refresh_time(**kwargs)
+        logger.debug("In iRODSSession's configure(). connection_refresh_time set to {}".format(connection_refresh_time))
         self.pool = Pool(account, application_name=kwargs.pop('application_name',''), connection_refresh_time=connection_refresh_time)
 
     def query(self, *args):
@@ -189,6 +190,11 @@ class iRODSSession(object):
 
     def get_connection_refresh_time(self, **kwargs):
         connection_refresh_time = -1
+        
+        connection_refresh_time = int(kwargs.get('refresh_time', -1))
+        if connection_refresh_time != -1:
+            return connection_refresh_time
+
         try:
             env_file = kwargs['irods_env_file']
         except KeyError:


### PR DESCRIPTION
In a previous PR (https://github.com/irods/python-irodsclient/pull/218), I added logic to re-create a connection is if it was not used more than a configurable amount of time. This was to deal with dropped irods connections in our Galaxy server after some period of inactivity.

After deploying this change, noticed that connections that were used recently, but were created along time ago, were still being dropped. Hence, changed the logic so any connection that was created more than a  configurable amount of time ago are re-created. This change stopped the dropped connection issue we were seeing.