### PR TITLE
227 228 zone user

### DIFF
--- a/irods/exception.py
+++ b/irods/exception.py
@@ -26,6 +26,10 @@ class CollectionDoesNotExist(DoesNotExist):
     pass
 
 
+class ZoneDoesNotExist(DoesNotExist):
+    pass
+
+
 class UserDoesNotExist(DoesNotExist):
     pass
 

--- a/irods/manager/user_manager.py
+++ b/irods/manager/user_manager.py
@@ -30,7 +30,8 @@ class UserManager(Manager):
         message_body = GeneralAdminRequest(
             "add",
             "user",
-            user_name,
+            user_name if not user_zone or user_zone == self.sess.zone \
+                      else "{}#{}".format(user_name,user_zone),
             user_type,
             user_zone,
             auth_str

--- a/irods/manager/zone_manager.py
+++ b/irods/manager/zone_manager.py
@@ -1,0 +1,50 @@
+from __future__ import absolute_import
+import logging
+
+from irods.models import Zone
+from irods.zone import iRODSZone
+from irods.manager import Manager
+from irods.message import GeneralAdminRequest, iRODSMessage
+from irods.api_number import api_number
+from irods.exception import ZoneDoesNotExist, NoResultFound
+
+logger = logging.getLogger(__name__)
+
+class ZoneManager(Manager):
+
+    def get(self, zone_name):
+        query = self.sess.query(Zone).filter(Zone.name == zone_name)
+
+        try:
+            result = query.one()
+        except NoResultFound:
+            raise ZoneDoesNotExist()
+        return iRODSZone(self, result)
+
+    def create(self, zone_name, zone_type):
+        message_body = GeneralAdminRequest(
+            "add",
+            "zone",
+            zone_name,
+            zone_type,
+        )
+        request = iRODSMessage("RODS_API_REQ", msg=message_body,
+                               int_info=api_number['GENERAL_ADMIN_AN'])
+        with self.sess.pool.get_connection() as conn:
+            conn.send(request)
+            response = conn.recv()
+        logger.debug(response.int_info)
+        return self.get(zone_name)
+
+    def remove(self, zone_name):
+        message_body = GeneralAdminRequest(
+            "rm",
+            "zone",
+            zone_name
+        )
+        request = iRODSMessage("RODS_API_REQ", msg=message_body,
+                               int_info=api_number['GENERAL_ADMIN_AN'])
+        with self.sess.pool.get_connection() as conn:
+            conn.send(request)
+            response = conn.recv()
+        logger.debug(response.int_info)

--- a/irods/models.py
+++ b/irods/models.py
@@ -22,6 +22,7 @@ class Model(six.with_metaclass(ModelBase, object)):
 class Zone(Model):
     id = Column(Integer, 'ZONE_ID', 101)
     name = Column(String, 'ZONE_NAME', 102)
+    type = Column(String, 'ZONE_TYPE', 103)
 
 
 class User(Model):

--- a/irods/session.py
+++ b/irods/session.py
@@ -11,6 +11,7 @@ from irods.manager.metadata_manager import MetadataManager
 from irods.manager.access_manager import AccessManager
 from irods.manager.user_manager import UserManager, UserGroupManager
 from irods.manager.resource_manager import ResourceManager
+from irods.manager.zone_manager import ZoneManager
 from irods.exception import NetworkException
 from irods.password_obfuscation import decode
 from irods import NATIVE_AUTH_SCHEME, PAM_AUTH_SCHEME
@@ -33,6 +34,7 @@ class iRODSSession(object):
         self.users = UserManager(self)
         self.user_groups = UserGroupManager(self)
         self.resources = ResourceManager(self)
+        self.zones = ZoneManager(self)
 
     def __enter__(self):
         return self

--- a/irods/test/zone_test.py
+++ b/irods/test/zone_test.py
@@ -1,0 +1,52 @@
+#! /usr/bin/env python
+from __future__ import absolute_import
+import os
+import sys
+import unittest
+
+from irods.models import User,Collection
+from irods.access import iRODSAccess
+from irods.collection import iRODSCollection
+from irods.exception import CollectionDoesNotExist
+import irods.test.helpers as helpers
+
+class TestRemoteZone(unittest.TestCase):
+
+    def setUp(self):
+        self.sess = helpers.make_session()
+
+    def tearDown(self):
+        """Close connections."""
+        self.sess.cleanup()
+
+    # This test should pass whether or not federation is configured:
+    def test_create_other_zone_user_227_228(self):
+        usercolls = []
+        session = self.sess
+        A_ZONE_NAME = 'otherZone'
+        A_ZONE_USER = 'alice'
+        try:
+            zoneB =  session.zones.create(A_ZONE_NAME,'remote')
+            zBuser = session.users.create(A_ZONE_USER,'rodsuser', A_ZONE_NAME, '')
+            usercolls = [ iRODSCollection(session.collections, result) for result in
+                          session.query(Collection).filter(Collection.owner_name == zBuser.name and 
+                                                     Collection.owner_zone == zBuser.zone) ]
+            self.assertEqual ([(u[User.name],u[User.zone]) for u in session.query(User).filter(User.zone == A_ZONE_NAME)],
+                              [(A_ZONE_USER,A_ZONE_NAME)])
+            zBuser.remove()
+            zoneB.remove()
+        finally:
+            for p in usercolls:
+                try:
+                    session.collections.get( p.path )
+                except CollectionDoesNotExist:
+                    continue
+                perm = iRODSAccess( 'own', p.path, session.username, session.zone)
+                session.permissions.set( perm, admin=True)
+                p.remove(force=True)
+
+
+if __name__ == '__main__':
+    # let the tests find the parent irods lib
+    sys.path.insert(0, os.path.abspath('../..'))
+    unittest.main()

--- a/irods/zone.py
+++ b/irods/zone.py
@@ -1,0 +1,21 @@
+from __future__ import absolute_import
+from irods.models import Zone
+
+
+class iRODSZone(object):
+
+    def __init__(self, manager, result=None):
+        """Construct an iRODSZone object."""
+        self.manager = manager
+        if result:
+            self.id = result[Zone.id]
+            self.name = result[Zone.name]
+            self.type = result[Zone.type]
+
+    def remove(self):
+        self.manager.remove(self.name)
+
+    def __repr__(self):
+        """Render a user-friendly string representation for the iRODSZone object."""
+        return "<iRODSZone {id} {name} {type}>".format(**vars(self))
+


### PR DESCRIPTION
Allows creation of zone entries, and foreign-zone user entries, in ICAT via the client.
