### PR TITLE
Add force option to data_object_manager create following the other functions.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -659,6 +659,16 @@ We can also query on access type using its numeric value, which will seem more n
 >>> data_objects_writable = list(session.query(DataObject,DataAccess,User)).filter(User.name=='alice',  DataAccess.type >= MODIFY)
 
 
+Managing users
+--------------
+
+You can create a user in the current zone using:
+>>> session.users.create('user', 'rodsuser', 'MyZone', auth_str)
+(the auth_str parameter is optional).
+If you want to create a user in a federated zone, use:
+>>> session.users.create('user', 'rodsuser', 'OtherZone', auth_str)
+
+
 And more...
 -----------
 

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -81,7 +81,7 @@ class DataObjectManager(Manager):
             return self.get(obj)
 
 
-    def create(self, path, resource=None, **options):
+    def create(self, path, resource=None, force=False, **options):
         options[kw.DATA_TYPE_KW] = 'generic'
 
         if resource:
@@ -92,6 +92,9 @@ class DataObjectManager(Manager):
                 options[kw.DEST_RESC_NAME_KW] = self.sess.default_resource
             except AttributeError:
                 pass
+
+        if force:
+            options[kw.FORCE_FLAG_KW] = ''
 
         message_body = FileOpenRequest(
             objPath=path,

--- a/irods/test/force_create.py
+++ b/irods/test/force_create.py
@@ -1,0 +1,51 @@
+#! /usr/bin/env python
+from __future__ import absolute_import
+import os
+import sys
+import unittest
+
+from irods.exception import OVERWRITE_WITHOUT_FORCE_FLAG
+import irods.test.helpers as helpers
+
+class TestForceCreate(unittest.TestCase):
+
+    def setUp(self):
+        self.sess = helpers.make_session()
+
+
+    def tearDown(self):
+        """Close connections."""
+        self.sess.cleanup()
+
+    # This test should pass whether or not federation is configured:
+    def test_force_create(self):
+        session = self.sess
+        FILE = '/a.txt'
+        try:
+            session.data_objects.unlink(FILE)
+        except:
+            pass
+        error = None
+        try:
+            session.data_objects.create(FILE)
+            session.data_objects.create(FILE)
+        except OVERWRITE_WITHOUT_FORCE_FLAG:
+            error = "OVERWRITE_WITHOUT_FORCE_FLAG"
+        self.assertEqual (error, "OVERWRITE_WITHOUT_FORCE_FLAG")
+        error = None
+        try:
+            session.data_objects.create(FILE, force=True)
+        except:
+            error = "Error creating with force"
+        self.assertEqual (error, None)
+        try:
+            session.data_objects.unlink(FILE)
+        except:
+            error = "Error cleaning up"
+        self.assertEqual (error, None)
+
+
+if __name__ == '__main__':
+    # let the tests find the parent irods lib
+    sys.path.insert(0, os.path.abspath('../..'))
+    unittest.main()

--- a/irods/test/force_create.py
+++ b/irods/test/force_create.py
@@ -12,7 +12,6 @@ class TestForceCreate(unittest.TestCase):
     def setUp(self):
         self.sess = helpers.make_session()
 
-
     def tearDown(self):
         """Close connections."""
         self.sess.cleanup()
@@ -20,7 +19,7 @@ class TestForceCreate(unittest.TestCase):
     # This test should pass whether or not federation is configured:
     def test_force_create(self):
         session = self.sess
-        FILE = '/a.txt'
+        FILE = '/{session.zone}/home/{session.username}/a.txt'.format(**locals())
         try:
             session.data_objects.unlink(FILE)
         except:


### PR DESCRIPTION
Needed to overwrite files in iRODS.