### PR TITLE
atomic metadata call for PRC

### DIFF
--- a/irods/api_number.py
+++ b/irods/api_number.py
@@ -176,4 +176,5 @@ api_number = {
     # 1100 - 1200 - SSL API calls
     "SSL_START_AN": 1100,
     "SSL_END_AN": 1101,
+    "ATOMIC_APPLY_METADATA_OPERATIONS_APN": 20002
 }

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -1,6 +1,7 @@
 import struct
 import logging
 import socket
+import json
 import xml.etree.ElementTree as ET
 from irods.message.message import Message
 from irods.message.property import (BinaryProperty, StringProperty,
@@ -67,6 +68,10 @@ class iRODSMessage(object):
         self.error = error
         self.bs = bs
         self.int_info = int_info
+
+    def get_json_encoded_struct (self):
+        Xml = ET.fromstring(self.msg.replace(b'\0',b''))
+        return json.loads(Xml.find('buf').text)
 
     @staticmethod
     def recv(sock):
@@ -236,6 +241,18 @@ class BinBytesBuf(Message):
     _name = 'BinBytesBuf_PI'
     buflen = IntegerProperty()
     buf = BinaryProperty()
+
+class BytesBuf(Message):
+    _name = 'BytesBuf_PI'
+    buflen = IntegerProperty()
+    buf = StringProperty()
+
+class JSONMessage(BytesBuf):
+    """A message body whose payload is just a BytesBuf containing JSON."""
+    def __init__(self, msg_struct):
+        """Initialize with a Python data structure that will be converted to JSON."""
+        s = json.dumps(msg_struct)
+        super(JSONMessage,self).__init__(buf=s,buflen=len(s))
 
 
 class PluginAuthMessage(Message):

--- a/irods/test/helpers.py
+++ b/irods/test/helpers.py
@@ -13,6 +13,7 @@ from irods.message import iRODSMessage
 from six.moves import range
 
 
+
 def make_session(**kwargs):
     try:
         env_file = kwargs['irods_env_file']
@@ -108,6 +109,23 @@ def make_flat_test_dir(dir_path, file_count=10, file_size=1024):
         # make random binary file
         with open(file_path, 'wb') as f:
             f.write(os.urandom(file_size))
+
+
+@contextlib.contextmanager
+def create_simple_resc_hierarchy (self, Root, Leaf):
+    d = tempfile.mkdtemp()
+    self.sess.resources.create(Leaf,'unixfilesystem',
+                           host = self.sess.host,
+                           path=d)
+    self.sess.resources.create(Root,'passthru')
+    self.sess.resources.add_child(Root,Leaf)
+    try:
+        yield ';'.join([Root,Leaf])
+    finally:
+        self.sess.resources.remove_child(Root,Leaf)
+        self.sess.resources.remove(Leaf)
+        self.sess.resources.remove(Root)
+        shutil.rmtree(d)
 
 
 def chunks(f, chunksize=io.DEFAULT_BUFFER_SIZE):


### PR DESCRIPTION
To address #244 .
This is a WIP and should be adjusted to accommodate a more succinct syntax.
We start by just jamming in the JSON directly ...
```python
  ses=get_session()
  reqs = {
    "entity_name": "/tempZone/home/rods/thing.cc",
    "entity_type": "data_object",
    "operations": [
      {
        "operation": "remove",
        "attribute": "a1",
        "value": "v1"
      },
      {
        "operation": "add",
        "attribute": "a2",
        "value": "v2",
        "units": "u2"
      }
    ]
  }
  ses.metadata.atomic( reqs )
```
It possibly should look more like ...
```
sys.metadata.atomic ( [ 'remove', iRODSMeta( 'a1','v1') ] ,   [ 'add', iRODSMeta( 'u2','v2',u2') ] , #...
)
```
or even:
```
[data|resc|coll|user].metadata.atomic ( [...],[...],...)
```