### PR TITLE
Add functions to retrieve temp password for own user or other user (as rodsAdmin)

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -7,12 +7,12 @@ import six
 import os
 import ssl
 import datetime
-
+import irods.password_obfuscation as obf
 
 from irods.message import (
     iRODSMessage, StartupPack, AuthResponse, AuthChallenge, AuthPluginOut,
     OpenedDataObjRequest, FileSeekResponse, StringStringMap, VersionResponse,
-    PluginAuthMessage, ClientServerNegotiation, Error)
+    PluginAuthMessage, ClientServerNegotiation, Error, GetTempPasswordOut)
 from irods.exception import get_exception_by_code, NetworkException
 from irods import (
     MAX_PASSWORD_LENGTH, RESPONSE_LEN,
@@ -566,3 +566,16 @@ class Connection(object):
 
         self.send(message)
         self.recv()
+
+    def temp_password(self):
+        request = iRODSMessage("RODS_API_REQ", msg=None,
+                               int_info=api_number['GET_TEMP_PASSWORD_AN'])
+
+        # Send and receive request
+        self.send(request)
+        response = self.recv()
+        logger.debug(response.int_info)
+
+        # Convert and return answer
+        msg = response.get_main_message(GetTempPasswordOut)
+        return obf.create_temp_password(msg.stringToHashWith, self.account.password)

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -495,6 +495,22 @@ class GeneralAdminRequest(Message):
     arg9 = StringProperty()
 
 
+class GetTempPasswordForOtherRequest(Message):
+    _name = 'getTempPasswordForOtherInp_PI'
+    targetUser = StringProperty()
+    unused = StringProperty()
+
+
+class GetTempPasswordForOtherOut(Message):
+    _name = 'getTempPasswordForOtherOut_PI'
+    stringToHashWith = StringProperty()
+
+
+class GetTempPasswordOut(Message):
+    _name = 'getTempPasswordOut_PI'
+    stringToHashWith = StringProperty()
+
+
 #define ticketAdminInp_PI "str *arg1; str *arg2; str *arg3; str *arg4; str *arg5; str *arg6;"
 
 class TicketAdminRequest(Message):

--- a/irods/password_obfuscation.py
+++ b/irods/password_obfuscation.py
@@ -275,3 +275,11 @@ def obfuscate_new_password(new, old, signature):
         new = new + padding[:lcopy]
 
     return scramble_v2(new, old, signature)
+
+
+def create_temp_password(temp_hash, source_password):
+    password = (temp_hash + source_password).ljust(100, chr(0))
+    password_md5 = hashlib.md5(password.encode('utf-8'))
+
+    # Return hexdigest
+    return password_md5.hexdigest()

--- a/irods/test/temp_password_test.py
+++ b/irods/test/temp_password_test.py
@@ -1,0 +1,86 @@
+#! /usr/bin/env python
+from __future__ import absolute_import
+import os
+import sys
+import unittest
+from irods.exception import UserDoesNotExist
+from irods.session import iRODSSession
+import irods.test.helpers as helpers
+
+
+class TestTempPassword(unittest.TestCase):
+    """ Suite of tests for setting and getting temporary passwords as rodsadmin or rodsuser
+    """
+    admin = None
+    new_user = 'bobby'
+    password = 'foobar'
+
+    @classmethod
+    def setUpClass(cls):
+        cls.admin = helpers.make_session()
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.admin.cleanup()
+
+    def test_temp_password(self):
+        # Make a new user
+        self.admin.users.create(self.new_user, 'rodsuser')
+        self.admin.users.modify(self.new_user, 'password', self.password)
+
+        # Login as the new test user, to retrieve a temporary password
+        with iRODSSession(host=self.admin.host,
+                          port=self.admin.port,
+                          user=self.new_user,
+                          password=self.password,
+                          zone=self.admin.zone) as session:
+            # Obtain the temporary password
+            conn = session.pool.get_connection()
+            temp_password = conn.temp_password()
+
+        # Open a new session with the temporary password
+        with iRODSSession(host=self.admin.host,
+                          port=self.admin.port,
+                          user=self.new_user,
+                          password=temp_password,
+                          zone=self.admin.zone) as session:
+
+            # do something that connects to the server
+            session.users.get(self.admin.username)
+
+        # delete new user
+        self.admin.users.remove(self.new_user)
+
+        # user should be gone
+        with self.assertRaises(UserDoesNotExist):
+            self.admin.users.get(self.new_user)
+
+    def test_set_temp_password(self):
+        # make a new user
+        temp_user = self.admin.users.create(self.new_user, 'rodsuser')
+
+        # obtain a temporary password as rodsadmin for another user
+        temp_password = temp_user.temp_password()
+
+        # open a session as the new user
+        with iRODSSession(host=self.admin.host,
+                          port=self.admin.port,
+                          user=self.new_user,
+                          password=temp_password,
+                          zone=self.admin.zone) as session:
+
+            # do something that connects to the server
+            session.users.get(self.new_user)
+
+        # delete new user
+        self.admin.users.remove(self.new_user)
+
+        # user should be gone
+        with self.assertRaises(UserDoesNotExist):
+            self.admin.users.get(self.new_user)
+
+
+if __name__ == '__main__':
+    # let the tests find the parent irods lib
+    sys.path.insert(0, os.path.abspath('../..'))
+    unittest.main()

--- a/irods/user.py
+++ b/irods/user.py
@@ -53,6 +53,9 @@ class iRODSUser(object):
     def remove(self):
         self.manager.remove(self.name, self.zone)
 
+    def temp_password(self):
+        return self.manager.temp_password_for_user(self.name)
+
 
 class iRODSUserGroup(object):
 


### PR DESCRIPTION
Our users login to our iRODS web application using federated SAML. The web application talk to iRODS as that user, by using the iRODS proxy user and a rodsAdmin account. To offer webdav access to our users, we're using the temporary password functionality to create a short-lived password. 

So far we were using the PHP API for this. But we're migrating to Django. So we needed the temp password functionality also in the Python.

This adds temp password functionality to the Python API. Both the function for setting your own temp password, or setting someone else temp password (as rodsAdmin). For the temp_password_for_user() I've also added a test.

