### PR TITLE
[285] adds tests for irods/irods#5548 and irods/irods#5848

### DIFF
--- a/irods/exception.py
+++ b/irods/exception.py
@@ -724,6 +724,10 @@ class NO_LOCAL_FILE_RSYNC_IN_MSI(UserInputException):
     code = -356000
 
 
+class LOCKED_DATA_OBJECT_ACCESS(SystemException):
+    code = -406000
+
+
 class FileDriverException(iRODSException):
     pass
 


### PR DESCRIPTION
Validates (from the Python client perspective) the commits:

  - https://github.com/irods/irods/commit/6d89ca1
  - https://github.com/irods/irods/commit/d8a7471
  - https://github.com/irods/irods/commit/42d54aa
  - https://github.com/irods/irods/commit/1b80f3a

which now allow:

  - marking an out-of-date replica as stale (refer to last line of
       https://github.com/irods/irods/issues/5548#issuecomment-919506139)
       when another replica is written by the client
  - writing in parallel mode to data objects on replication resources as
       well as to non-unique replicas on the system (ref: irods/irods#5848)