### PR TITLE
test setting/resetting inheritance

### DIFF
--- a/irods/collection.py
+++ b/irods/collection.py
@@ -17,10 +17,14 @@ class iRODSCollection(object):
             self.name = irods_basename(result[Collection.name])
             self.create_time = result[Collection.create_time]
             self.modify_time = result[Collection.modify_time]
-            self.inheritance = result[Collection.inheritance]
+            self._inheritance = result[Collection.inheritance]
             self.owner_name = result[Collection.owner_name]
             self.owner_zone = result[Collection.owner_zone]
         self._meta = None
+
+    @property
+    def inheritance(self):
+        return bool(self._inheritance) and self._inheritance != "0"
 
     @property
     def metadata(self):

--- a/irods/manager/access_manager.py
+++ b/irods/manager/access_manager.py
@@ -113,14 +113,19 @@ class AccessManager(Manager):
                                user_lookup[r[access_column.user_id]].zone  ) for r in rows ]
         return acls
 
+
     def set(self, acl, recursive=False, admin=False):
         prefix = 'admin:' if admin else ''
+
+        userName_=acl.user_name
+        zone_=acl.user_zone
+        if acl.access_name.endswith('inherit'): zone_ = userName_ = ''
 
         message_body = ModAclRequest(
             recursiveFlag=int(recursive),
             accessLevel='{prefix}{access_name}'.format(prefix=prefix, **vars(acl)),
-            userName=acl.user_name,
-            zone=acl.user_zone,
+            userName=userName_,
+            zone=zone_,
             path=acl.path
         )
         request = iRODSMessage("RODS_API_REQ", msg=message_body,

--- a/irods/test/collection_test.py
+++ b/irods/test/collection_test.py
@@ -37,7 +37,7 @@ class TestCollection(unittest.TestCase):
         coll = self.sess.collections.get(self.test_coll_path)
         self.assertIsNotNone(coll.create_time)
         self.assertIsNotNone(coll.modify_time)
-        self.assertIsNotNone(coll.inheritance)
+        self.assertFalse(coll.inheritance)
         self.assertIsNotNone(coll.owner_name)
         self.assertIsNotNone(coll.owner_zone)
 


### PR DESCRIPTION
Mainly to show an example of this, and mimic the behavior of ichmod
ie. setting user and zone to "" when (no)inherit is the access_name.

Also, uses the new inheritance attribute of collections.