### PR TITLE
iRODS Xml-protocol compatibility

### DIFF
--- a/irods/message/quasixml.py
+++ b/irods/message/quasixml.py
@@ -3,14 +3,17 @@
 # at least for the features used by python-irodsclient.
 
 class Element():
-    """Represents <name>body</name>.
-       body is either a string or a list of sub-elements.
+    """
+    Represents <name>body</name>.
+
+    (Where `body' is either a string or a list of sub-elements.)
     """
 
     @property
     def tag(self): return self.name
 
     def __init__(self, name, body):
+        """Initialize with the tag's name and the body (i.e. content)."""
         if body == []:
             # Empty element.
             self.text = None
@@ -23,16 +26,16 @@ class Element():
         self.body = body
 
     def find(self, name):
-        """Get first matching child element by name"""
+        """Get first matching child element by name."""
         for x in self.findall(name):
             return x
 
     def findall(self, name):
-        """Get matching child elements by name"""
+        """Get matching child elements by name."""
         return list(self.findall_(name))
 
     def findall_(self, name):
-        """Get matching child elements by name (generator variant)"""
+        """Get matching child elements by name (generator variant)."""
         return (el for el in self.body if el.name == name)
 
     # For debugging convenience:
@@ -47,7 +50,9 @@ class Element():
 
 
 class Token(object):
+    """A utility class for parsing XML."""
     def __init__(self, s):
+        """Create a `Token' object from `s', the text comprising the parsed token."""
         self.text = s
     def __repr__(self):
         return str(type(self).__name__) + '(' + self.text.decode('utf-8') + ')'
@@ -62,10 +67,10 @@ class TokenCData(Token):
     """Textual element body"""
 
 class QuasiXmlParseError(Exception):
-    """Indicates parse failure of XML protocol data"""
+    """Indicates parse failure of XML protocol data."""
 
 def tokenize(s):
-    """Parse an XML-ish string into a list of tokens"""
+    """Parse an XML-ish string into a list of tokens."""
     tokens = []
 
     # Consume input until empty.
@@ -106,10 +111,10 @@ def tokenize(s):
             tokens.append(TokenCData(cdata))
 
 def fromtokens(tokens):
-    """Parse XML-ish tokens into an Element"""
+    """Parse XML-ish tokens into an Element."""
 
     def parse_elem(tokens):
-        """Parse some tokens into one Element, and return unconsumed tokens"""
+        """Parse some tokens into one Element, and return unconsumed tokens."""
         topen, tokens = tokens[0], tokens[1:]
         if type(topen) is not TokenTagOpen:
             raise QuasiXmlParseError('protocol error: data does not start with open tag')
@@ -148,19 +153,15 @@ def fromstring(s):
     return fromtokens(tokenize(s))
 
 
-entities = [('&', '&amp;'), # note: order matters. & must be encoded first.
-            ('<', '&lt;'),
-            ('>', '&gt;'),
-            ('`', '&apos;'), # https://github.com/irods/irods/issues/4132
-            ('"', '&quot;')]
-
 def encode_entities(s):
-    for k, v in entities:
+    from . import XML_entities_active
+    for k, v in XML_entities_active():
         s = s.replace(k, v)
     return s
 
 def decode_entities(s):
-    rev = list(entities)
+    from . import XML_entities_active
+    rev = list(XML_entities_active())
     rev.reverse() # (make sure &amp; is decoded last)
     for k, v in rev:
         s = s.replace(v, k)

--- a/irods/message/quasixml.py
+++ b/irods/message/quasixml.py
@@ -6,6 +6,10 @@ class Element():
     """Represents <name>body</name>.
        body is either a string or a list of sub-elements.
     """
+
+    @property
+    def tag(self): return self.name
+
     def __init__(self, name, body):
         if body == []:
             # Empty element.
@@ -42,7 +46,7 @@ class Element():
         return '{}({})'.format(self.name, repr(self.body))
 
 
-class Token():
+class Token(object):
     def __init__(self, s):
         self.text = s
     def __repr__(self):

--- a/irods/test/message_test.py
+++ b/irods/test/message_test.py
@@ -8,7 +8,8 @@ import unittest
 if __name__ == '__main__':
     sys.path.insert(0, os.path.abspath('../..'))
 
-from xml.etree import ElementTree as ET
+from irods.message import ET
+
 # from base64 import b64encode, b64decode
 from irods.message import (StartupPack, AuthResponse, IntegerIntegerMap,
                            IntegerStringMap, StringStringMap, GenQueryRequest,
@@ -44,7 +45,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(xml_str, expected)
 
         sup2 = StartupPack(('rods', 'tempZone'), ('rods', 'tempZone'))
-        sup2.unpack(ET.fromstring(expected))
+        sup2.unpack(ET().fromstring(expected))
         self.assertEqual(sup2.irodsProt, 2)
         self.assertEqual(sup2.reconnFlag, 3)
         self.assertEqual(sup2.proxyUser, "rods")
@@ -66,7 +67,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(ar.pack(), expected)
 
         ar2 = AuthResponse()
-        ar2.unpack(ET.fromstring(expected))
+        ar2.unpack(ET().fromstring(expected))
         self.assertEqual(ar2.response, b"hello")
         self.assertEqual(ar2.username, "rods")
 
@@ -85,7 +86,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(iip.pack(), expected)
 
         iip2 = IntegerIntegerMap()
-        iip2.unpack(ET.fromstring(expected))
+        iip2.unpack(ET().fromstring(expected))
         self.assertEqual(iip2.iiLen, 2)
         self.assertEqual(iip2.inx, [4, 5])
         self.assertEqual(iip2.ivalue, [1, 2])
@@ -105,7 +106,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(kvp.pack(), expected)
 
         kvp2 = StringStringMap()
-        kvp2.unpack(ET.fromstring(expected))
+        kvp2.unpack(ET().fromstring(expected))
         self.assertEqual(kvp2.ssLen, 2)
         self.assertEqual(kvp2.keyWord, ["one", "two"])
         self.assertEqual(kvp2.svalue, ["three", "four"])
@@ -140,7 +141,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(gq.pack(), expected)
 
         gq2 = GenQueryRequest()
-        gq2.unpack(ET.fromstring(expected))
+        gq2.unpack(ET().fromstring(expected))
         self.assertEqual(gq2.maxRows, 4)
         self.assertEqual(gq2.continueInx, 3)
         self.assertEqual(gq2.partialStartIndex, 2)
@@ -170,7 +171,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(sr.pack(), expected)
 
         sr2 = GenQueryResponseColumn()
-        sr2.unpack(ET.fromstring(expected))
+        sr2.unpack(ET().fromstring(expected))
         self.assertEqual(sr2.attriInx, 504)
         self.assertEqual(sr2.reslen, 64)
         self.assertEqual(sr2.value, ["one", "two"])
@@ -193,7 +194,7 @@ class TestMessages(unittest.TestCase):
         self.assertEqual(gqo.pack(), expected)
 
         gqo2 = GenQueryResponse()
-        gqo2.unpack(ET.fromstring(expected))
+        gqo2.unpack(ET().fromstring(expected))
 
         self.assertEqual(gqo2.rowCnt, 2)
         self.assertEqual(gqo2.pack(), expected)


### PR DESCRIPTION
Allow special characters in object names, including XML-special entities like` & < > " ' `etc