### PR TITLE
[315] skip cleanup() if session.pool is None

### DIFF
--- a/irods/connection.py
+++ b/irods/connection.py
@@ -493,7 +493,7 @@ class Connection(object):
 
         # Default case, PAM login will send a new password
         if password is None:
-            password = self.account.password
+            password = self.account.password or ''
 
         # authenticate
         auth_req = iRODSMessage(msg_type='RODS_API_REQ', int_info=703)

--- a/irods/connection.py
+++ b/irods/connection.py
@@ -388,7 +388,7 @@ class Connection(object):
             username=self.account.proxy_user + '#' + self.account.proxy_zone
         )
         gsi_request = iRODSMessage(
-            msg_type='RODS_API_REQ', int_info=704, msg=gsi_msg)
+            msg_type='RODS_API_REQ', int_info=api_number['AUTH_RESPONSE_AN'], msg=gsi_msg)
         self.send(gsi_request)
         self.recv()
         # auth_response = self.recv()
@@ -535,7 +535,7 @@ class Connection(object):
         pwd_msg = AuthResponse(
             response=encoded_pwd, username=self.account.proxy_user)
         pwd_request = iRODSMessage(
-            msg_type='RODS_API_REQ', int_info=704, msg=pwd_msg)
+            msg_type='RODS_API_REQ', int_info=api_number['AUTH_RESPONSE_AN'], msg=pwd_msg)
         self.send(pwd_request)
         self.recv()
 

--- a/irods/session.py
+++ b/irods/session.py
@@ -58,7 +58,10 @@ class iRODSSession(object):
 
     def __del__(self):
         self.do_configure = {}
-        self.cleanup()
+        # If self.pool has been fully initialized (ie. no exception was
+        #   raised during __init__), then try to clean up.
+        if self.pool is not None:
+            self.cleanup()
 
     def cleanup(self):
         for conn in self.pool.active | self.pool.idle:

--- a/irods/user.py
+++ b/irods/user.py
@@ -46,8 +46,8 @@ class iRODSUser(object):
 
     def modify_password(self, old_value, new_value, modify_irods_authentication_file = False):
         self.manager.modify_password(old_value,
-                                         new_value,
-                                         modify_irods_authentication_file = modify_irods_authentication_file)
+                                     new_value,
+                                     modify_irods_authentication_file = modify_irods_authentication_file)
 
     def modify(self, *args, **kwargs):
         self.manager.modify(self.name, *args, **kwargs)


### PR DESCRIPTION
An uninitiated session (represented by an iRODSSession object
with pool attribute of None) was, upon deletion, calling cleanup()
despite having no connections (idle or active) to clean up. This
corrects the bug and prevents the error message that was spooling
to the console as a result.