### PR TITLE
changes for parallel put to S3

### DIFF
--- a/irods/exception.py
+++ b/irods/exception.py
@@ -746,6 +746,10 @@ class NO_LOCAL_FILE_RSYNC_IN_MSI(UserInputException):
     code = -356000
 
 
+class OBJ_PATH_DOES_NOT_EXIST(iRODSException):
+    code = -358000
+
+
 class LOCKED_DATA_OBJECT_ACCESS(SystemException):
     code = -406000
 


### PR DESCRIPTION
More-or-less the PRC end of the capability behind the UGM S3 parallel put/get Lightning Talk.

Send numthreads/datasize kw on first open( ) operation in the S3 plugin.

Conform with iput/iget per-thread byte counts

Data objects' open(...) in PRC can now be deferred operations, to simplify the code organization for the auto-switching parallel put.