### PR TITLE
Defused xml

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -463,13 +463,22 @@ As of PRC v1.1.0, we can mitigate both problems by switching in the QUASI_XML pa
     from irods.message import (XML_Parser_Type, ET)
     ET( XML_Parser.QUASI_XML, session.server_version )
 
-The same can be accomplished by putting a server-version-specific tuple into a special environment variable prior to running
-any application code:
-::
-    Bash-Shell> export PYTHON_IRODSCLIENT_QUASI_XML_DEFAULT_SERVER_VERSION=4,2,8
+Two dedicated environment variables may also be used to customize the Python client's XML parsing behavior via the
+setting of global defaults during start-up.
 
-This example causes the Python iRODS Client to select the QUASI_XML parser with a 4.2.8 server dialect as the default for
-any operations on iRODS client APIs.  This may also be overridden, on a per-thread basis, using the aforementioned ET() call.
+For example, we can set the default parser to QUASI_XML, optimized for use with version 4.2.8 of the iRODS server,
+in the following manner:
+::
+    Bash-Shell> export PYTHON_IRODSCLIENT_DEFAULT_XML=QUASI_XML PYTHON_IRODSCLIENT_QUASI_XML_SERVER_VERSION=4,2,8
+
+Other alternatives for PYTHON_IRODSCLIENT_DEFAULT_XML are "STANDARD_XML" and "SECURE_XML".  These two latter options
+denote use of the xml.etree and defusedxml modules, respectively.
+
+Only the choice of "QUASI_XML" is affected by the specification of a particular server version.
+
+Finally, note that these global defaults, once set, may be overridden on a per-thread basis using
+:code:`ET(parser_type, server_version)`.  We can also revert the current thread's XML parser back to the
+global default by calling :code:`ET(None)`.
 
 
 Rule Execution

--- a/irods/results.py
+++ b/irods/results.py
@@ -3,6 +3,13 @@ from prettytable import PrettyTable
 
 from irods.models import ModelBase
 from six.moves import range
+from six import PY3
+
+
+try:
+    unicode         # Python 2
+except NameError:
+    unicode = str
 
 
 class ResultSet(object):
@@ -41,8 +48,13 @@ class ResultSet(object):
         except (TypeError, ValueError):
             return (col, value)
 
+    _str_encode = staticmethod(lambda x:x.encode('utf-8') if type(x) is unicode else x)
+
+    _get_column_values = ( lambda self,index: [(col, col.value[index]) for col in self.cols]
+           ) if PY3 else ( lambda self,index: [(col, self._str_encode(col.value[index])) for col in self.cols] )
+
     def _format_row(self, index):
-        values = [(col, col.value[index]) for col in self.cols]
+        values = self._get_column_values(index)
         return dict([self._format_attribute(col.attriInx, value) for col, value in values])
 
     def __getitem__(self, index):

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -123,7 +123,7 @@ class TestDataObjOps(unittest.TestCase):
         Then we assert the file contents and dispose of the data object."""
 
         try:
-            self.sess.data_objects.create(data_object_path, **{kw.RESC_NAME_KW: root_resc} )
+            self.sess.data_objects.create(data_object_path, resource = root_resc)
             for _ in range( seconds_to_wait_for_replicas ):
                 if required_num_replicas <= len( self.sess.data_objects.get(data_object_path).replicas ): break
                 time.sleep(1)
@@ -137,7 +137,7 @@ class TestDataObjOps(unittest.TestCase):
             fd1.write(b'book')
             fd2.close()
             fd1.close()
-            with self.sess.data_objects.open(data_object_path, 'r', **{kw.RESC_NAME_KW: root_resc} ) as f:
+            with self.sess.data_objects.open(data_object_path, 'r', **{kw.DEST_RESC_NAME_KW: root_resc} ) as f:
                 self.assertEqual(f.read(), b'books\n')
         except Exception as e:
             logging.debug('Exception %r in [%s], called from [%s]', e, my_function_name(), caller_func)

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -25,7 +25,7 @@ import irods.test.helpers as helpers
 import irods.keywords as kw
 from irods.manager import data_object_manager
 from irods.message import RErrorStack
-from irods.message import ( ET, XML_Parser_Type )
+from irods.message import ( ET, XML_Parser_Type, default_XML_parser, current_XML_parser )
 from datetime import datetime
 from tempfile import NamedTemporaryFile
 from irods.test.helpers import (unique_name, my_function_name)
@@ -1511,7 +1511,7 @@ class TestDataObjOps(unittest.TestCase):
                     os.unlink(name)
             if vault:
                 self.sess.resources.remove( resc_name )
-        self.assertIs( ET(), xml.etree.ElementTree )
+        self.assertIs( default_XML_parser(), current_XML_parser() )
 
     def test_register_with_xml_special_chars(self):
         test_dir = helpers.irods_shared_tmp_dir()

--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -9,6 +9,7 @@ from irods.manager.metadata_manager import InvalidAtomicAVURequest
 from irods.models import (DataObject, Collection, Resource)
 import irods.test.helpers as helpers
 from six.moves import range
+from six import PY3
 
 
 class TestMeta(unittest.TestCase):
@@ -165,7 +166,8 @@ class TestMeta(unittest.TestCase):
         assert meta[1].units == self.unit1
 
         assert meta[2].name == attribute
-        assert meta[2].value == value
+        testValue = (value if PY3 else value.encode('utf8'))
+        assert meta[2].value == testValue
 
 
     def test_add_obj_meta_empty(self):

--- a/irods/test/query_test.py
+++ b/irods/test/query_test.py
@@ -369,8 +369,8 @@ class TestQuery(unittest.TestCase):
             results = self.sess.query(DataObject, Collection.name).filter(DataObject.path == test_file).first()
             result_logical_path = os.path.join(results[Collection.name], results[DataObject.name])
             result_physical_path = results[DataObject.path]
-            self.assertEqual(result_logical_path, obj_path.decode('utf8'))
-            self.assertEqual(result_physical_path, test_file.decode('utf8'))
+            self.assertEqual(result_logical_path, obj_path)
+            self.assertEqual(result_physical_path, test_file)
         finally:
             if results: self.sess.data_objects.unregister(obj_path)
             os.remove(test_file)

--- a/irods/test/unicode_test.py
+++ b/irods/test/unicode_test.py
@@ -6,7 +6,7 @@ import sys
 import unittest
 from irods.models import Collection, DataObject
 import xml.etree.ElementTree as ET
-from irods.message import (ET as ET_set, XML_Parser_Type)
+from irods.message import (ET as ET_set, XML_Parser_Type, current_XML_parser, default_XML_parser)
 import logging
 import irods.test.helpers as helpers
 
@@ -79,11 +79,11 @@ class TestUnicodeNames(unittest.TestCase):
             path = homepath + "/" + dataname
             self.sess.data_objects.create( path )
         finally:
-            ET_set( XML_Parser_Type.STANDARD_XML )
+            ET_set( None )
             self.sess.data_objects.unlink (path, force = True)
 
-        # assert successful switch back to STANDARD_XML parser
-        self.assertTrue( ET_set(), ET )
+        # assert successful switch back to global default
+        self.assertIs( current_XML_parser(), default_XML_parser() )
 
     def test_files(self):
         # Query for all files in test collection

--- a/irods/test/unicode_test.py
+++ b/irods/test/unicode_test.py
@@ -9,6 +9,7 @@ import xml.etree.ElementTree as ET
 from irods.message import (ET as ET_set, XML_Parser_Type, current_XML_parser, default_XML_parser)
 import logging
 import irods.test.helpers as helpers
+from six import PY3
 
 logger = logging.getLogger(__name__)
 
@@ -90,16 +91,24 @@ class TestUnicodeNames(unittest.TestCase):
         query = self.sess.query(DataObject.name, Collection.name).filter(
             Collection.name == self.coll_path)
 
+        # Python2 compatibility note:  In keeping with the principle of least surprise, we now ensure
+        # queries return values of 'str' type in Python2.  When and if these quantities have a possibility
+        # of representing unicode quantities, they can then go through a decode stage.
+
+        encode_unless_PY3 = (lambda x:x) if PY3 else (lambda x:x.encode('utf8'))
+        decode_unless_PY3 = (lambda x:x) if PY3 else (lambda x:x.decode('utf8'))
+
         for result in query:
             # check that we got back one of our original names
-            assert result[DataObject.name] in self.names
+            assert result[DataObject.name] in ( [encode_unless_PY3(n) for n in self.names] )
 
             # fyi
-            logger.info(
-                u"{0}/{1}".format(result[Collection.name], result[DataObject.name]))
+            logger.info( u"{0}/{1}".format( decode_unless_PY3(result[Collection.name]),
+                                            decode_unless_PY3(result[DataObject.name]) )
+                       )
 
             # remove from set
-            self.names.remove(result[DataObject.name])
+            self.names.remove(decode_unless_PY3(result[DataObject.name]))
 
         # make sure we got all of them
         self.assertEqual(0, len(self.names))

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ setup(name='python-irodsclient',
       install_requires=[
                         'six>=1.10.0',
                         'PrettyTable>=0.7.2',
+                        'defusedxml',
                         # - the new syntax:
                         #'futures; python_version == "2.7"'
                         ],


### PR DESCRIPTION
Add the SECURE_XML option to PRC, and make the `ET( )` call more flexible as far as changing and reverting XML parser behavior.  Slightly alter the the environment variable(s) that dictate XML parser global defaults to make better sense.