### PR TITLE
[_3][_345] Allow tests to pass and accommodate older Python

### DIFF
--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -12,6 +12,7 @@ import defusedxml.ElementTree as ET_secure_xml
 from . import quasixml as ET_quasi_xml
 from collections import namedtuple
 import os
+import fcntl
 import ast
 import threading
 from irods.message.message import Message
@@ -150,19 +151,23 @@ except NameError:
     UNICODE = str
 
 
+
+# Necessary for older python (<3.7):
+_socket_is_blocking = (lambda self: 0 == fcntl.fcntl(self.fileno(), fcntl.F_GETFL) & os.O_NONBLOCK)
+
 def _recv_message_in_len(sock, size):
     size_left = size
     retbuf = None
 
     # Get socket properties for debug and exception messages.
     host, port = sock.getpeername()
-    is_blocking = sock.getblocking()
+    is_blocking = _socket_is_blocking(sock)
     timeout = sock.gettimeout()
 
-    logger.debug(f'host: {host}')
-    logger.debug(f'port: {port}')
-    logger.debug(f'is_blocking: {is_blocking}')
-    logger.debug(f'timeout: {timeout}')
+    logger.debug('host: %s',host)
+    logger.debug('port: %d',port)
+    logger.debug('is_blocking: %s',is_blocking)
+    logger.debug('timeout: %s',timeout)
 
     while size_left > 0:
         try:

--- a/irods/test/connection_test.py
+++ b/irods/test/connection_test.py
@@ -41,12 +41,17 @@ class TestConnections(unittest.TestCase):
         # set port back
         self.sess.pool.account.port = saved_port
 
-    def test_send_failure(self):
+    def test_1_multiple_disconnect(self):
         with self.sess.pool.get_connection() as conn:
-            # try to close connection twice, 2nd one should fail
+            # disconnect() may now be called multiple times without error.
+            # (Note, here it is called implicitly upon exiting the with-block.)
             conn.disconnect()
-            with self.assertRaises(NetworkException):
-                conn.disconnect()
+
+    def test_2_multiple_disconnect(self):
+        conn = self.sess.pool.get_connection()
+        # disconnect() may now be called multiple times without error.
+        conn.disconnect()
+        conn.disconnect()
 
     def test_reply_failure(self):
         with self.sess.pool.get_connection() as conn:

--- a/irods/test/pool_test.py
+++ b/irods/test/pool_test.py
@@ -10,6 +10,7 @@ import tempfile
 import time
 import json
 import unittest
+import socket
 import irods.test.helpers as helpers
 from irods.connection import DESTRUCTOR_MSG
 
@@ -244,6 +245,10 @@ class TestPool(unittest.TestCase):
     # Test to confirm the connection destructor log message is actually
     # logged to file, to confirm the destructor is called
     def test_connection_destructor_called(self):
+
+        if self.sess.host != socket.gethostname() and not LOCALHOST_REGEX.match (self.sess.host):
+            self.skipTest('local test only - client dot does not like the extra logging')
+
         # Set 'irods_connection_refresh_time' to '3' (in seconds) in
         # ~/.irods/irods_environment.json file. This means any connection
         # that was created more than 3 seconds ago will be dropped and


### PR DESCRIPTION
   - don't use f"" style strings

   - getblocking socket method doesn't exist before Python3.7

   - skip test that makes logging explode in client dot

   - in test, do not assert a connection fails disconnect() the second time.