### PR TITLE
[#369] Simplify code for metadata and ticket APIs

### DIFF
--- a/irods/manager/metadata_manager.py
+++ b/irods/manager/metadata_manager.py
@@ -5,7 +5,7 @@ import copy
 from os.path import dirname, basename
 
 from irods.manager import Manager
-from irods.message import (MetadataRequest, iRODSMessage, JSON_Message, session_cache)
+from irods.message import (MetadataRequest, iRODSMessage, JSON_Message)
 from irods.api_number import api_number
 from irods.models import (DataObject, Collection, Resource,
                           User, DataObjectMeta, CollectionMeta, ResourceMeta, UserMeta)
@@ -100,7 +100,7 @@ class MetadataManager(Manager):
             raise ValueError('Empty value in ' + repr(meta))
 
         resource_type = self._model_class_to_resource_type(model_cls)
-        message_body = session_cache(MetadataRequest,self.sess)(
+        message_body = MetadataRequest(
             "add",
             "-" + resource_type,
             path,
@@ -118,7 +118,7 @@ class MetadataManager(Manager):
 
     def remove(self, model_cls, path, meta, **opts):
         resource_type = self._model_class_to_resource_type(model_cls)
-        message_body = session_cache(MetadataRequest,self.sess)(
+        message_body = MetadataRequest(
             "rm",
             "-" + resource_type,
             path,
@@ -137,7 +137,7 @@ class MetadataManager(Manager):
     def copy(self, src_model_cls, dest_model_cls, src, dest, **opts):
         src_resource_type = self._model_class_to_resource_type(src_model_cls)
         dest_resource_type = self._model_class_to_resource_type(dest_model_cls)
-        message_body = session_cache(MetadataRequest,self.sess)(
+        message_body = MetadataRequest(
             "cp",
             "-" + src_resource_type,
             "-" + dest_resource_type,
@@ -155,7 +155,7 @@ class MetadataManager(Manager):
 
     def set(self, model_cls, path, meta, **opts):
         resource_type = self._model_class_to_resource_type(model_cls)
-        message_body = session_cache(MetadataRequest,self.sess)(
+        message_body = MetadataRequest(
             "set",
             "-" + resource_type,
             path,

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -661,47 +661,36 @@ class ObjCopyRequest(Message):
     srcDataObjInp_PI = SubmessageProperty(FileOpenRequest)
     destDataObjInp_PI = SubmessageProperty(FileOpenRequest)
 
-#in iRODS <= 4.2.11:
-# define ModAVUMetadataInp_PI "str *arg0; str *arg1; str *arg2; str *arg3;
-# str *arg4; str *arg5; str *arg6; str *arg7;  str *arg8;  str *arg9;"
 
-#in iRODS > 4.2.11:
 # define ModAVUMetadataInp_PI "str *arg0; str *arg1; str *arg2; str *arg3;
 # str *arg4; str *arg5; str *arg6; str *arg7;  str *arg8;  str *arg9; struct KeyValPair_PI"
 
-def MetadataRequest(session):
+class MetadataRequest(Message):
+    _name = 'ModAVUMetadataInp_PI'
 
-    SERVER_REQUIRES_KEYVAL_PAIRS = (session.server_version >= (4,2,12))
+    def __init__(self, *args, **metadata_opts):
+        super(MetadataRequest, self).__init__()
+        for i in range(len(args)):
+            if args[i]:
+                setattr(self, 'arg%d' % i, args[i])
+        self.KeyValPair_PI = StringStringMap(metadata_opts)
 
-    class MetadataRequest_(Message):
-        _name = 'ModAVUMetadataInp_PI'
+    arg0 = StringProperty()
+    arg1 = StringProperty()
+    arg2 = StringProperty()
+    arg3 = StringProperty()
+    arg4 = StringProperty()
+    arg5 = StringProperty()
+    arg6 = StringProperty()
+    arg7 = StringProperty()
+    arg8 = StringProperty()
+    arg9 = StringProperty()
 
-        def __init__(self, *args, **metadata_opts):
-            super(MetadataRequest_, self).__init__()
-            for i in range(len(args)):
-                if args[i]:
-                    setattr(self, 'arg%d' % i, args[i])
-            if SERVER_REQUIRES_KEYVAL_PAIRS:
-                self.KeyValPair_PI = StringStringMap(metadata_opts)
+    KeyValPair_PI = SubmessageProperty(StringStringMap)
 
-        arg0 = StringProperty()
-        arg1 = StringProperty()
-        arg2 = StringProperty()
-        arg3 = StringProperty()
-        arg4 = StringProperty()
-        arg5 = StringProperty()
-        arg6 = StringProperty()
-        arg7 = StringProperty()
-        arg8 = StringProperty()
-        arg9 = StringProperty()
 
-        if SERVER_REQUIRES_KEYVAL_PAIRS:
-            KeyValPair_PI = SubmessageProperty(StringStringMap)
-
-    return MetadataRequest_
-
-    # define modAccessControlInp_PI "int recursiveFlag; str *accessLevel; str
-    # *userName; str *zone; str *path;"
+# define modAccessControlInp_PI "int recursiveFlag; str *accessLevel; str
+# *userName; str *zone; str *path;"
 
 
 class ModAclRequest(Message):
@@ -799,36 +788,26 @@ class GetTempPasswordOut(Message):
 #in iRODS >= 4.2.11:
 #define ticketAdminInp_PI "str *arg1; str *arg2; str *arg3; str *arg4; str *arg5; str *arg6; struct KeyValPair_PI;"
 
-def TicketAdminRequest(session):
 
-    # class is different depending on server version
+class TicketAdminRequest(Message):
+    _name = 'ticketAdminInp_PI'
 
-    SERVER_REQUIRES_KEYVAL_PAIRS = (session.server_version >= (4,2,11))
+    def __init__(self, *args,**ticketOpts):
+        super(TicketAdminRequest, self).__init__()
+        for i in range(6):
+            if i < len(args) and args[i]:
+                setattr(self, 'arg{0}'.format(i+1), str(args[i]))
+            else:
+                setattr(self, 'arg{0}'.format(i+1), "")
+        self.KeyValPair_PI = StringStringMap(ticketOpts)
 
-    class TicketAdminRequest_(Message):
-        _name = 'ticketAdminInp_PI'
-
-        def __init__(self, *args,**ticketOpts):
-            super(TicketAdminRequest_, self).__init__()
-            for i in range(6):
-                if i < len(args) and args[i]:
-                    setattr(self, 'arg{0}'.format(i+1), str(args[i]))
-                else:
-                    setattr(self, 'arg{0}'.format(i+1), "")
-            if SERVER_REQUIRES_KEYVAL_PAIRS:
-                self.KeyValPair_PI = StringStringMap(ticketOpts)
-
-        arg1 = StringProperty()
-        arg2 = StringProperty()
-        arg3 = StringProperty()
-        arg4 = StringProperty()
-        arg5 = StringProperty()
-        arg6 = StringProperty()
-
-        if SERVER_REQUIRES_KEYVAL_PAIRS:
-            KeyValPair_PI = SubmessageProperty(StringStringMap)
-
-    return TicketAdminRequest_
+    arg1 = StringProperty()
+    arg2 = StringProperty()
+    arg3 = StringProperty()
+    arg4 = StringProperty()
+    arg5 = StringProperty()
+    arg6 = StringProperty()
+    KeyValPair_PI = SubmessageProperty(StringStringMap)
 
 
 #define specificQueryInp_PI "str *sql; str *arg1; str *arg2; str *arg3; str *arg4; str *arg5; str *arg6; str *arg7; str *arg8; str *arg9; str *arg10; int maxRows; int continueInx; int rowOffset; int options; struct KeyValPair_PI;"
@@ -1111,17 +1090,3 @@ def empty_gen_query_out(cols):
         SqlResult_PI=sql_results
     )
     return gqo
-
-
-import weakref
-
-cache_ = {
-  MetadataRequest: weakref.WeakKeyDictionary()
-}
-
-def session_cache (func,session,*args):
-    retval = cache_[func].get(session)
-    if retval is None:
-        cache_[func][session] = retval = func(*([session]+list(args)))
-    return retval
-

--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -226,6 +226,10 @@ class TestMeta(unittest.TestCase):
         try:
             d = user = None
             adm = self.sess
+
+            if adm.server_version <= (4,2,11):
+                self.skipTest('ADMIN_KW not valid for Metadata API in iRODS 4.2.11 and previous')
+
             # Create a rodsuser, and a session for that roduser.
             user = adm.users.create ( 'bobby','rodsuser' )
             user.modify('password','bpass')

--- a/irods/test/ticket_test.py
+++ b/irods/test/ticket_test.py
@@ -82,6 +82,9 @@ class TestRodsUserTicketOps(unittest.TestCase):
 
     def test_admin_keyword_for_tickets (self):
 
+        if helpers.make_session().server_version < (4,2,11):
+            self.skipTest('ADMIN_KW not valid for Tickets API before iRODS 4.2.11')
+
         N_TICKETS = 3
 
         # Create some tickets as alice.

--- a/irods/ticket.py
+++ b/irods/ticket.py
@@ -58,7 +58,7 @@ class Ticket(object):
         return ''.join(random.SystemRandom().choice(source_characters) for _ in range(length))
 
     def _api_request(self,cmd_string,*args, **opts):
-        message_body = TicketAdminRequest(self.session)(cmd_string, self.ticket, *args, **opts)
+        message_body = TicketAdminRequest(cmd_string, self.ticket, *args, **opts)
         message = iRODSMessage("RODS_API_REQ", msg=message_body, int_info=api_number['TICKET_ADMIN_AN'])
 
         with self.session.pool.get_connection() as conn:


### PR DESCRIPTION
I had incorrectly assumed the ability to add the `KeyValPair_PI` to the end of the packStruct message would be dependent on server version.  With this change we'll be sending with the keyvalpair part (necessary for the admin flag in the metadata API) regardless of server version.  It will then be ignored by the older servers, which don't need that options part anyway.