### PR TITLE
[#392] expose parent_id, parent_name and resc_hierarchy for resource objects

### DIFF
--- a/print_resc_properties.py
+++ b/print_resc_properties.py
@@ -1,0 +1,12 @@
+from irods.resource import iRODSResource
+from irods.models import Resource
+import irods.test.helpers as h
+import sys
+
+s = h.make_session()
+
+r = s.resources.get(sys.argv[1])
+
+print('id = ',r.parent_id)
+print('name = ',r.parent_name)
+print('resc_hier = ',r.resc_hierarchy)


### PR DESCRIPTION
Main motivation: `resc.parent_id` and `resc.parent_name` are explicit in what they provide, whereas `resc.parent` (an already existing `iRODSResource` attribute) is just what Genquery returns in RESC_PARENT (that is, the parent's name on iRODS <= 4.1 and parent's ID on iRODS >=4.2) See #392 