### PR TITLE
[#420] store integer codes & strings for access levels

### DIFF
--- a/irods/access.py
+++ b/irods/access.py
@@ -1,4 +1,42 @@
+import collections
+
 class iRODSAccess(object):
+
+    codes = { key:value for key,value in dict(  # copied from iRODS server code:
+        null                 = 1000,            # server/core/include/irods/catalog_utilities.hpp
+        execute              = 1010,
+        read_annotation      = 1020,
+        read_system_metadata = 1030,
+        read_metadata        = 1040,
+        read_object          = 1050,
+        write_annotation     = 1060,
+        create_metadata      = 1070,
+        modify_metadata      = 1080,
+        delete_metadata      = 1090,
+        administer_object    = 1100,
+        create_object        = 1110,
+        modify_object        = 1120,
+        delete_object        = 1130,
+        create_token         = 1140,
+        delete_token         = 1150,
+        curate               = 1160,
+        own                  = 1200
+    ).items() if key in (
+            # These are copied from ichmod help text.
+            'own',
+            'delete_object',
+            'write', 'modify_object',
+            'create_object',
+            'delete_metadata',
+            'modify_metadata',
+            'create_metadata',
+            'read', 'read_object',
+            'read_metadata',
+            'null'
+        )
+    }
+
+    strings = collections.OrderedDict(sorted((number,string) for string,number in codes.items()))
 
     def __init__(self, access_name, path, user_name='', user_zone='', user_type=None):
         self.access_name = access_name


### PR DESCRIPTION
Creates two dictionaries, allowing bidirectional access between access codes (integers) to corresponding strings and vice versa.  Where integers are keys, an orderedDict is used.  
So we can do this to get a neat and succinct table of codes:
```
>>> import irods.access, pprint
>>> pprint.pprint(tuple(irods.access.iRODSAccess.strings.items()))
((1000, 'null'),
 (1010, 'execute'),
 (1020, 'read_annotation'),
 (1030, 'read_system_metadata'),
 (1040, 'read_metadata'),
 (1050, 'read_object'),
 (1060, 'write_annotation'),
 (1070, 'create_metadata'),
 (1080, 'modify_metadata'),
 (1090, 'delete_metadata'),
 (1100, 'administer_object'),
 (1110, 'create_object'),
 (1120, 'modify_object'),
 (1130, 'delete_object'),
 (1140, 'create_token'),
 (1150, 'delete_token'),
 (1160, 'curate'),
 (1200, 'own'))
```