### PR TITLE
[#434] AVU fields must be strings (and all but units must be non-null)

### DIFF
--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -14,6 +14,8 @@ import irods.keywords as kw
 from irods.session import iRODSSession
 from six.moves import range
 from six import PY3
+from irods.message import Bad_AVU_Field
+
 
 
 class TestMeta(unittest.TestCase):
@@ -441,6 +443,14 @@ class TestMeta(unittest.TestCase):
             finally:
                 if d: d.unlink(force = True)
                 helpers.remove_unused_metadata(session)
+
+    def test_nonstring_as_AVU_value_raises_an_error__issue_434(self):
+        with self.assertRaisesRegexp(Bad_AVU_Field,'incorrect type'):
+            self.coll.metadata.set("an_attribute",0)
+
+    def test_empty_string_as_AVU_value_raises_an_error__issue_434(self):
+        with self.assertRaisesRegexp(Bad_AVU_Field,'zero-length'):
+            self.coll.metadata.set("an_attribute","")
 
 if __name__ == '__main__':
     # let the tests find the parent irods lib


### PR DESCRIPTION
**Edit:** superceded by events.  

**This previously read:**
We can now do obj.metadata.set('attr',i) where i is an integer, and not worry about message truncation when i == 0.

**But, right here and now:**
It seems we've decided that fields passed over the wire must be strings or None. (None is allowed only in the **units** field, and even then it's represented as a zero-length string on the wire.)  AVUs (as represented by `irods.meta.iRODSMeta` ) must by convention have attribute and value fields that are non-zero-length strings (even though `imeta set -d <path> attr ""` setting an AVU with an empty value field is still permitted in iCommands as of iRODS 4.2.11.)

PRC will enforce this convention / restriction by raising an error when attempting to send non-string (or zero-length) attribute or value over the wire using the fundamental metadata operations.