### PR TITLE
Allow non-default string types in all metadata calls

### DIFF
--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -24,6 +24,7 @@ class Bad_AVU_Field(Exception):
 
 _TUPLE_LIKE_TYPES = (tuple, list)
 
+
 def _qxml_server_version( var ):
     val = os.environ.get( var, '()' )
     vsn = (val and ast.literal_eval( val ))
@@ -154,6 +155,7 @@ except NameError:
     # Python 3
     UNICODE = str
 
+_METADATA_FIELD_TYPES = {str,UNICODE,bytes}
 
 
 # Necessary for older python (<3.7):
@@ -685,7 +687,8 @@ class MetadataRequest(Message):
 
             # Raise usage error if any of the AVU fields (args 3 to 5 inclusive) do not meet the above constraints.
             if i in (3,4,5):
-                if type(arg) not in ({str, UNICODE} if i<5 else {str, UNICODE, NoneType}):
+                if type(arg) not in (_METADATA_FIELD_TYPES if i<5
+                                     else {NoneType,}|_METADATA_FIELD_TYPES):
                     error = Bad_AVU_Field("AVU %s (%r) has incorrect type. AVU fields must be strings, except for units, which could be None." % (field_name(i),arg))
                 elif i<5 and not(arg):
                     error = Bad_AVU_Field("AVU %s (%r) is zero-length." % (field_name(i), arg))

--- a/irods/meta.py
+++ b/irods/meta.py
@@ -1,4 +1,4 @@
-
+import six
 
 class iRODSMeta(object):
 
@@ -95,6 +95,12 @@ class iRODSMetaCollection(object):
         """
         Returns a list of iRODSMeta associated with a given key
         """
+        if six.PY2:
+            if isinstance(key, unicode):
+                key = key.encode('utf8')
+        else:
+            if isinstance(key, bytes):
+                key = key.decode('utf8')
         if not isinstance(key, str):
             raise TypeError
         return [m for m in self._meta if m.name == key]

--- a/irods/test/query_test.py
+++ b/irods/test/query_test.py
@@ -540,6 +540,12 @@ class TestQuery(unittest.TestCase):
         if results:
             Rule(self.sess).remove_by_id( results[0][RuleExec.id] )
 
+    def test_utf8_equality_in_query__issue_442(self):
+        name = u'prefix-\u1000-suffix'
+        self.sess.data_objects.create(u'{}/{}'.format(self.coll_path, name))
+        query = self.sess.query(DataObject).filter( DataObject.name == name.encode('utf8'),
+                                                    DataObject.collection_id == self.coll.id)
+        self.assertEqual(1, len(list(query)))
 
     def test_not_like_operator__issue_443(self):
         name_search_pattern = '%_issue_443.non_matching'


### PR DESCRIPTION
Here we patch the ModAVUMetadata interface in the Python client to allow both Unicode and bytestring fields everywhere, regardless of which string type is the norm for the running Python interpreter.

Included also:
   - a test to ensure metadata queries, also, can match bytestring and Unicode equally well
   - an extra test that creates one data object with a unicode name, but queries for it using the bytestring equivalent. 