### PR TITLE
protect against use of bad parameters in modify_password

### DIFF
--- a/irods/manager/user_manager.py
+++ b/irods/manager/user_manager.py
@@ -8,11 +8,11 @@ from irods.manager import Manager
 from irods.message import UserAdminRequest, GeneralAdminRequest, iRODSMessage, GetTempPasswordForOtherRequest, GetTempPasswordForOtherOut
 from irods.exception import UserDoesNotExist, GroupDoesNotExist, NoResultFound, CAT_SQL_ERR
 from irods.api_number import api_number
-from irods.user import iRODSUser, iRODSGroup
+from irods.user import iRODSUser, iRODSGroup, Bad_password_change_parameter
 import irods.password_obfuscation as obf
+from .. import MAX_PASSWORD_LENGTH
 
 logger = logging.getLogger(__name__)
-
 
 class UserManager(Manager):
 
@@ -133,6 +133,10 @@ class UserManager(Manager):
                                   the absolute path of an IRODS_AUTHENTICATION_FILE to be altered.
         """
         with self.sess.pool.get_connection() as conn:
+
+            if old_value != self.sess.pool.account.password or not isinstance(new_value, str) \
+                                                            or not(3 <= len(new_value) <= MAX_PASSWORD_LENGTH - 8):
+                raise Bad_password_change_parameter
 
             hash_new_value = obf.obfuscate_new_password(new_value, old_value, conn.client_signature)
 

--- a/irods/user.py
+++ b/irods/user.py
@@ -5,6 +5,8 @@ from irods.exception import NoResultFound
 
 _Not_Defined = ()
 
+class Bad_password_change_parameter(Exception): pass
+
 class iRODSUser(object):
 
     def __init__(self, manager, result=None):


### PR DESCRIPTION
The `modify_password` call uses USER_ADMIN_AN (aka rcUserAdmin)'s sub-interface "userpw" and is available for rodsusers to change their own passwords.  Various exceptions can bubble up in this call, including CAT_PASSWORD_ENCODING_ERROR and PASSWORD_EXCEEDS_MAX_SIZE.  Here we regularize this by pre-screening parameters that might cause such a server error and throwing up a single Exception type (`Bad_password_change_parameter`) instead.

This also prevents a user from being able to corrupt the catalog entry containing their password which is possible in all server versions to date up to 4.3.0 and 4.2.11, probably including 4.2.12 as well. Notably the userpw interface throws no error when this corruption happens.  An attempt to change the password to something 25 chars or longer when an incorrect old password is provided is the trigger.  For this reason a client must at all costs protect against sending an bad old-password value.