### PR TITLE
redirect to resource server in data.open

### DIFF
--- a/demo-thread.py
+++ b/demo-thread.py
@@ -1,0 +1,51 @@
+import gc
+import sys
+from irods.session import _weakly_reference, SessionThread, iRODSSession
+from irods.test import helpers as helpers
+
+def f(ses):
+        c = helpers.home_collection(ses)
+        print (ses.collections.get(c))
+
+class MyThread(SessionThread):
+
+    def __init__(self, sess = None, func = None, **kwargs):
+        super(MyThread,self).__init__(**kwargs)
+        self.sess = sess
+        if sess:
+            _weakly_reference(sess, parent_thread = self)
+        self.func = func
+
+    def run(self):
+        self.func(self.sess)
+
+class my_iRODSSession(iRODSSession):
+    def cleanup(self,*arg,**kwarg):
+        print("cleanup called on {self}".format(**locals()))
+        return super(my_iRODSSession,self).cleanup(*arg,**kwarg)
+
+if __name__ == '__main__':
+    import irods.session
+
+    def _main_thread_sessions():
+        return () if irods.session._sessions is None \
+          else list(irods.session._sessions.keys())
+
+    s = my_iRODSSession( host='localhost',
+                         port=1247,
+                         user='rods',
+                         password='rods',
+                         zone='tempZone'
+                       )
+    t = MyThread(
+                    sess = s,
+                    func = f,
+                    )
+    t.start()
+    t.join()
+    del t
+    del s
+    print("->thread successfully joined.")
+    gc.collect()
+    print("-> garbage collected.")
+    print("atexit will be calling cleanup on:", _main_thread_sessions())

--- a/irods/account.py
+++ b/irods/account.py
@@ -5,6 +5,10 @@ class iRODSAccount(object):
                  password=None, client_user=None,
                  server_dn=None, client_zone=None, **kwargs):
 
+        # possible overrides
+        for k,v in kwargs.pop('overrides',{}).items():
+            if k =='irods_host': irods_host = v
+
         self.authentication_scheme = irods_authentication_scheme.lower()
         self.host = irods_host
         self.port = int(irods_port)

--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -204,3 +204,4 @@ class iRODSDataObjectFileRaw(io.RawIOBase):
 
     def seekable(self):
         return True
+

--- a/irods/manager/__init__.py
+++ b/irods/manager/__init__.py
@@ -13,3 +13,6 @@ class Manager(object):
 
     def __init__(self, sess):
         self.sess = sess
+
+    def _set_manager_session(self, sess):
+        self.sess = sess

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -21,6 +21,7 @@ import json
 import logging
 
 
+
 MAXIMUM_SINGLE_THREADED_TRANSFER_SIZE = 32 * ( 1024 ** 2)
 
 DEFAULT_NUMBER_OF_THREADS = 0   # Defaults for reasonable number of threads -- optimized to be

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -66,7 +66,7 @@ class DataObjectManager(Manager):
         # Example: $ export IRODS_VERSION_OVERRIDE="4,2,9" ;  python -m irods.parallel ...
         # ---
         # Delete the following line on resolution of https://github.com/irods/irods/issues/5932 :
-        if getattr(self.sess,'ticket__',None) is not None: return False
+        if self.sess.ticket__: return False
         server_version = ( ast.literal_eval(os.environ.get('IRODS_VERSION_OVERRIDE', '()' )) or server_version_hint or 
                            self.server_version )
         if num_threads == 1 or ( server_version < parallel.MINIMUM_SERVER_VERSION ):
@@ -128,7 +128,7 @@ class DataObjectManager(Manager):
             .filter(DataObject.collection_id == parent.id)\
             .add_keyword(kw.ZONE_KW, path.split('/')[1])
 
-        if hasattr(self.sess,'ticket__'):
+        if self.sess.ticket__:
             query = query.filter(Collection.id != 0) # a no-op, but necessary because CAT_SQL_ERR results if the ticket
                                                      # is for a DataObject and we don't explicitly join to Collection
 

--- a/irods/test/connection_test.py
+++ b/irods/test/connection_test.py
@@ -83,6 +83,7 @@ class TestConnections(unittest.TestCase):
             # Set a very short socket timeout and remove all pre-existing socket connections.
             # This forces a new connection to be made for any ensuing connections to the iRODS server.
 
+            sess = obj.manager.sess
             sess.connection_timeout = timeout = 0.01
             sess.cleanup()
 


### PR DESCRIPTION
Use GET_HOST_FOR_{GET,PUT} APIs to establish client sessions on a data object's appropriate resource server when doing reads(GETs) or writes(PUTs).

The existing sessions are cloned, but with the (resource-)appropriate hostname replacing the old value.  In this way, login details (such as SSL) should be the same.

For data objects outside of the local zone, no redirection is performed. 