### PR TITLE
client "plugin" modules for authentication.

### DIFF
--- a/irods/__init__.py
+++ b/irods/__init__.py
@@ -55,6 +55,7 @@ GSI_OID = "1.3.6.1.4.1.3536.1.1"  # taken from http://j.mp/2hDeczm
 
 PAM_AUTH_PLUGIN = 'PAM'
 PAM_AUTH_SCHEME = PAM_AUTH_PLUGIN.lower()
+PAM_AUTH_SCHEMES = (PAM_AUTH_SCHEME, 'pam_password')
 
 DEFAULT_CONFIG_PATH = os.path.expanduser('~/.python_irodsclient')
 settings_path_environment_variable = 'PYTHON_IRODSCLIENT_CONFIGURATION_PATH'

--- a/irods/account.py
+++ b/irods/account.py
@@ -10,7 +10,12 @@ class iRODSAccount(object):
             if k =='irods_host':
                 irods_host = v
 
-        self.authentication_scheme = irods_authentication_scheme.lower()
+        tuplify = lambda _: _ if isinstance(_,(list,tuple)) else (_,)
+        schemes = [_.lower() for _ in tuplify(irods_authentication_scheme)]
+
+        self._original_authentication_scheme = schemes[-1]
+        self.authentication_scheme = schemes[0]
+
         self.host = irods_host
         self.port = int(irods_port)
         self.proxy_user = self.client_user = irods_user_name

--- a/irods/auth/__init__.py
+++ b/irods/auth/__init__.py
@@ -1,0 +1,24 @@
+from __future__ import print_function
+__all__ = [ 'pam_password', 'native' ]
+
+AUTH_PLUGIN_PACKAGE = 'irods.auth'
+
+import importlib
+
+def load_plugins(subset=set(), _reload = False):
+    if not subset:
+        subset = set(__all__)
+    dir_ = set(globals()) & set(__all__) # plugins already loaded
+    for s in subset:
+        if s not in dir_ or _reload:
+            mod = importlib.import_module('.'+s, package = AUTH_PLUGIN_PACKAGE)
+            if _reload:
+                importlib.reload(mod)
+        dir_ |= {s}
+    return dir_
+
+# TODO(#499): X models a class which we could define here as a base for various server or client state machines
+#             as appropriate for the various authentication types.
+
+class X:
+        pass

--- a/irods/auth/native.py
+++ b/irods/auth/native.py
@@ -1,0 +1,10 @@
+
+def login(conn):
+    conn._login_native()
+
+# TODO (#499): Here, we could define client & server auth_state classes (ie state machines mimicking the mechanics
+#              of 4.3+ iCommands/iRods-runtime authentication framework), using this pattern for an inheritance hook.
+from . import X as X_base
+class X(X_base):
+        pass
+

--- a/irods/auth/pam_password.py
+++ b/irods/auth/pam_password.py
@@ -1,0 +1,7 @@
+def login(conn):
+    conn._login_pam()
+#   # in the future we might need cross-plugin calls:
+#   native_login(conn)  # see below for import
+
+# Pattern for when you need to import from sibling plugins:
+from .native import login as native_login

--- a/irods/client_configuration/__init__.py
+++ b/irods/client_configuration/__init__.py
@@ -84,6 +84,19 @@ class DataObjects(iRODSConfiguration):
 
 data_objects = DataObjects()
 
+class LegacyAuth(iRODSConfiguration):
+    __slots__ = ('pam',)
+    class Pam(iRODSConfiguration):
+        __slots__ = ('time_to_live_in_hours', 'password_for_auto_renew', 'store_password_to_environment')
+        def __init__(self):
+            self.time_to_live_in_hours = 0 # -> We default to the server's TTL preference.
+            self.password_for_auto_renew = ''
+            self.store_password_to_environment = False
+    def __init__(self):
+        self.pam = self.Pam()
+
+legacy_auth = LegacyAuth()
+
 # Exposes the significant settable attributes of an iRODSConfiguration object:
 def _config_names(root):
     slots = getattr(root,'__slots__',())

--- a/irods/test/pam.bats/funcs
+++ b/irods/test/pam.bats/funcs
@@ -1,0 +1,108 @@
+dot_to_space() {
+  sed 's/\./ /g'<<<"$1"
+}
+
+CLEANUP=$':\n'
+
+GT() { (return 1); echo $?; }
+LT() { (return -1); echo $?; }
+EQ() { (return 0); echo $?; }
+
+compare_int_tuple() {
+    local x=($1) y=($2)
+    local lx=${#x[@]} ly=${#y[@]}
+    local i maxlen=$((lx > ly ? lx : ly))
+    for ((i=0;i<maxlen;i++)) {
+        if [ $i -ge $lx ]; then return `LT`; fi
+        if [ $i -ge $ly ]; then return `GT`; fi
+        if [ ${x[$i]} -lt ${y[$i]} ]; then return `LT`; fi
+        if [ ${x[$i]} -gt ${y[$i]} ]; then return `GT`; fi
+    }
+    return `EQ`
+}
+
+irods_version()
+{
+  local X=''
+  [[ `ihelp -h|tail -1` =~ [0-9]+(\.[0-9]+)+ ]] && X=${BASH_REMATCH[0]}
+  echo "$X"
+}
+
+pam_test_would_take_too_long()
+{
+    compare_int_tuple "$(dot_to_space `irods_version`)" "$(dot_to_space 4.3.1)"
+    [ $? = `LT` ]
+}
+
+get_auth_param () { iadmin get_grid_configuration authentication $1; }
+
+with_change_auth_params_for_test()
+{
+  local restore_cmd=""
+
+  # Use saved environment (must be rodsadmin).
+  if [ -e ~/.irods.$$ ]; then
+      export IRODS_ENVIRONMENT_FILE=~/.irods.$$/irods_environment.json
+      export IRODS_AUTHENTICATION_FILE=~/.irods.$$/.irodsA
+  fi
+
+  while [ $# -ge 2 ]; do
+    local reset_value=$(iadmin get_grid_configuration authentication $1)
+    restore_cmd+=$'\n'"iadmin set_grid_configuration authentication $1 $reset_value"
+    [ -n "$2" ] && iadmin set_grid_configuration authentication $1 $2
+    shift 2
+  done
+
+  unset IRODS_ENVIRONMENT_FILE IRODS_AUTHENTICATION_FILE
+
+  if [[ $SET_CLEANUP = [yY]* ]]; then
+    CLEANUP+="$restore_cmd"
+  fi
+}
+
+_begin_pam_environment_and_password() {
+    local ENV='{
+    "irods_host": "localhost",
+    "irods_zone_name": "tempZone",
+    "irods_port": 1247,
+    "irods_user_name": "alice",
+    "irods_authentication_scheme": "pam_password",
+    "irods_client_server_negotiation": "request_server_negotiation",
+    "irods_client_server_policy": "CS_NEG_REQUIRE",
+    "irods_ssl_ca_certificate_file": "/etc/irods/ssl/irods.crt",
+    "irods_ssl_verify_server": "cert",
+    "irods_encryption_key_size": 16,
+    "irods_encryption_salt_size": 8,
+    "irods_encryption_num_hash_rounds": 16,
+    "irods_encryption_algorithm": "AES-256-CBC"
+    }'
+
+    rm -fr ~/.irods.$$
+    mv ~/.irods ~/.irods.$$
+    mkdir ~/.irods
+    echo "$ENV" > ~/.irods/irods_environment.json
+    iinit <<<"$1" 2>/dev/tty
+}
+
+_end_pam_environment_and_password() {
+    rm -fr ~/.irods
+    mv ~/.irods.$$ ~/.irods
+}
+
+setup_pam_login_for_alice() {
+    sudo useradd alice --create-home
+    local PASSWD=${1:-test123}
+    sudo chpasswd <<<"alice:$PASSWD"
+    iadmin mkuser alice rodsuser
+    _begin_pam_environment_and_password "$PASSWD"
+}
+
+finalize_pam_login_for_alice() {
+    _end_pam_environment_and_password
+    iadmin rmuser alice
+    sudo userdel alice --remove
+}
+
+test_specific_cleanup() {
+  eval "$CLEANUP"
+}

--- a/irods/test/pam.bats/test001_pam_password_expiration.bats
+++ b/irods/test/pam.bats/test001_pam_password_expiration.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+
+. "$BATS_TEST_DIRNAME"/funcs
+PYTHON=python3
+
+# Setup/prerequisites are same as for login_auth_test.
+# Run as ubuntu user with sudo; python_irodsclient must be installed (in either ~/.local or a virtualenv)
+#
+
+PASSWD=test123
+
+setup()
+{
+    setup_pam_login_for_alice $PASSWD
+}
+
+teardown()
+{
+    finalize_pam_login_for_alice
+    test_specific_cleanup
+}
+
+@test f001 {
+
+    # Define the core Python to be run, basically a minimal code block ensuring that we can authenticate to iRODS
+    # without an exception being raised.
+
+    local SCRIPT="
+import irods.test.helpers as h
+ses = h.make_session()
+ses.collections.get(h.home_collection(ses))
+print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
+"
+
+    # Test that the first run of the code in $SCRIPT is successful, i.e. normal authenticated operations are possible.
+
+    local OUTPUT=$($PYTHON -c "$SCRIPT")
+
+    [[ $OUTPUT =~ ^env_auth_scheme=pam_password$ ]]
+
+    SET_CLEANUP=yes \
+    with_change_auth_params_for_test password_min_time 4 \
+                                     password_max_time 5
+
+    # Test that running the $SCRIPT raises an exception if the PAM password has expired.
+
+    iinit <<<"$PASSWD"
+    HOME_COLLECTION=$(ipwd)
+    sleep 9
+    OUTPUT=$($PYTHON -c "$SCRIPT" 2>&1 >/dev/null || true)
+    grep 'RuntimeError: Time To Live' <<<"$OUTPUT"
+
+    # Test that the $SCRIPT, when run with proper settings, can successfully reset the password.
+
+    with_change_auth_params_for_test password_max_time 3600
+
+    OUTPUT=$($PYTHON -c "import irods.client_configuration as cfg
+cfg.legacy_auth.pam.password_for_auto_renew = '$PASSWD'
+cfg.legacy_auth.pam.time_to_live_in_hours = 1
+cfg.legacy_auth.pam.store_password_to_environment = True
+$SCRIPT")
+
+    [[ $OUTPUT =~ ^env_auth_scheme=pam_password$ ]]
+
+    # Test that iCommands can authenticate with the newly written .irodsA file
+
+    iquest "%s" "select COLL_NAME where COLL_NAME like '%/home/alice%'"| grep "^$HOME_COLLECTION\$"
+}


### PR DESCRIPTION
Provides a client compatibility layer for the iRODS 4.3 authentication framework.

Presently we still rely on the the old routines (for example, we call back to `irods.Connection._login_pam` when attempting the "pam_password" auth scheme).  But this dispatch-to-module approach is likely to be more maintainable/extensible than the legacy way of doing things.