### PR TITLE
[#474] include query model to discover quotas

### DIFF
--- a/irods/__init__.py
+++ b/irods/__init__.py
@@ -1,4 +1,4 @@
-from .version import __version__
+from .version import __version__, version_as_tuple, version_as_string
 
 import logging
 import os

--- a/irods/message/__init__.py
+++ b/irods/message/__init__.py
@@ -10,6 +10,7 @@ import irods.exception as ex
 import xml.etree.ElementTree as ET_xml
 import defusedxml.ElementTree as ET_secure_xml
 from . import quasixml as ET_quasi_xml
+from ..api_number import api_number
 from collections import namedtuple
 import os
 import ast
@@ -783,6 +784,18 @@ class _admin_request_base(Message):
 
 class GeneralAdminRequest(_admin_request_base):
     _name = 'generalAdminInp_PI'
+
+def _do_GeneralAdminRequest(_session_or_accessor, *args):
+    sess = _session_or_accessor
+    if callable(sess):
+        sess = sess()
+    message_body = GeneralAdminRequest(*args)
+    request = iRODSMessage("RODS_API_REQ", msg=message_body,
+                           int_info=api_number['GENERAL_ADMIN_AN'])
+    with sess.pool.get_connection() as conn:
+        conn.send(request)
+        response = conn.recv()
+    logger.debug(response.int_info)
 
 
 # define userAdminInp_PI "str *arg0; str *arg1; str *arg2; str *arg3;

--- a/irods/models.py
+++ b/irods/models.py
@@ -199,6 +199,14 @@ class Keywords(Model):
     chksum = Keyword(String, 'chksum')
 
 
+class Quota(Model):
+    user_id = Column(Integer, 'COL_QUOTA_USER_ID', 2000)
+    resc_id = Column(Integer, 'COL_QUOTA_RESC_ID', 2001)
+    limit = Column(Integer, 'COL_QUOTA_LIMIT', 2002)
+    over = Column(Integer, 'COL_QUOTA_OVER', 2003)
+    modify_time = Column(DateTime,'COL_QUOTA_MODIFY_TIME', 2004)
+
+
 class TicketQuery:
     """Various model classes for querying attributes of iRODS tickets.
 

--- a/irods/user.py
+++ b/irods/user.py
@@ -9,6 +9,13 @@ class Bad_password_change_parameter(Exception): pass
 
 class iRODSUser(object):
 
+    def remove_quota(self, resource = 'total'):
+        self.manager.remove_quota(self.name, resource = resource)
+
+    # TODO: remove this in branch 2.x (#482)
+    def set_quota(self, amount, resource = 'total'):
+        self.manager.set_quota(self.name, amount, resource = resource)
+
     def __init__(self, manager, result=None):
         self.manager = manager
         if result:
@@ -65,6 +72,12 @@ class iRODSUser(object):
 
 
 class iRODSGroup(object):
+
+    def remove_quota(self, resource = 'total'):
+        self.set_quota(amount = 0, resource = resource)
+
+    def set_quota(self, amount, resource = 'total'):
+        self.manager.set_quota(self.name, amount, resource = resource)
 
     def __init__(self, manager, result=None):
         self.manager = manager

--- a/irods/version.py
+++ b/irods/version.py
@@ -1,1 +1,9 @@
+import os 
+
 __version__ = '1.1.9'
+
+def version_as_string():
+    return os.environ.get('PYTHON_IRODSCLIENT_VERSION', __version__.strip())
+
+def version_as_tuple():
+    return tuple(int(x) for x in version_as_string().split('.'))

--- a/irods/version.py
+++ b/irods/version.py
@@ -1,4 +1,4 @@
-import os 
+import os
 
 __version__ = '1.1.9'
 


### PR DESCRIPTION
With this change, we can now use the `irods.models.Quota` class to discover group user guotas...
A client endpoint has also been added for creating and removing group quotas. (individual user quotas aka `iadmin suq` are no longer supported.)