### PR TITLE
Document pam settings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1322,17 +1322,17 @@ like :code:`<session>.permissions`, except that the :code:`<session>.acls.get(..
 Quotas (v1.1.9+)
 ----------------
 
-Quotas may be set for a group:
+Quotas may be set for a group::
 
     session.groups.set_quota('my_group', 50000, resource = 'my_limited_resource')
 
-or per user, prior to iRODS 4.3.0:
+or per user, prior to iRODS 4.3.0::
 
     session.users.set_quota('alice', 100000)
 
 (The default for the resource parameter is "total", denoting a general quota usage not bound to a particular resource.)
 
-The Quota model is also available for queries.  So, to determine the space remaining for a certain group on a given resource:
+The Quota model is also available for queries.  So, to determine the space remaining for a certain group on a given resource::
 
     from irods.models import Quota
     session.groups.calculate_usage()
@@ -1340,7 +1340,7 @@ The Quota model is also available for queries.  So, to determine the space remai
     space_left_in_bytes = list(session.query(Quota.over).filter(Quota.user_id == session.groups.get(group).id,
                                                                 Quota.resc_id == session.resources.get(resource).id))[0][Quota.over] * -1
 
-And, to remove all quotas for a given group, one might (as a rodsadmin) do the following:
+And, to remove all quotas for a given group, one might (as a rodsadmin) do the following::
 
     from irods.models import Resource, Quota
     resc_map = dict([(x[Resource.id],x[Resource.name]) for x in sess.query(Resource)] + [(0,'total')])

--- a/README.rst
+++ b/README.rst
@@ -360,6 +360,39 @@ descriptions for each one currently available, including the names of the enviro
   - Environment Variable Override: :code:`PYTHON_IRODSCLIENT_CONFIG__DATA_OBJECTS__AUTO_CLOSE`
 
 
+* Setting: Number of hours to request for the new password entry's TTL (Time To Live) when auto-renewing PAM-authenticated sessions.
+
+  - Dotted Name: :code:`legacy_auth.pam.time_to_live_in_hours`
+
+  - Type: :code:`int`
+
+  - Default Value: :code:`0` (Meaning: conform to server's default TTL value.)
+
+  - Environment Variable Override: :code:`PYTHON_IRODSCLIENT_CONFIG__LEGACY_AUTH__PAM__TIME_TO_LIVE_IN_HOURS`
+
+
+* Setting: Plaintext PAM password value, to be used when auto-renewing PAM-authenticated sessions because TTL has expired.
+
+  - Dotted Name: :code:`legacy_auth.pam.password_for_auto_renew`
+
+  - Type: :code:`str`
+
+  - Default Value: :code:`""` (Meaning: no password is set, and thus no automatic attempts will be made at auto-renewing PAM authentication.)
+
+  - Environment Variable Override: :code:`PYTHON_IRODSCLIENT_CONFIG__LEGACY_AUTH__PAM__PASSWORD_FOR_AUTO_RENEW`.  (But note that use of the environment variable could pose a threat to password security.)
+
+
+* Setting: Whether to write the (native encoded) new hashed password to the iRODS password file.  This step is only performed while auto-renewing PAM authenticated sessions.
+
+  - Dotted Name: :code:`legacy_auth.pam.store_password_to_environment`
+
+  - Type: :code:`bool`
+
+  - Default Value: :code:`False`
+
+  - Environment Variable Override: :code:`PYTHON_IRODSCLIENT_CONFIG__LEGACY_AUTH__PAM__STORE_PASSWORD_TO_ENVIRONMENT`
+
+
 * Setting: Default choice of XML parser for all new threads.
 
   - Dotted Name: :code:`connections.xml_parser_default`


### PR DESCRIPTION
This pull request only documents pam related settings.  It really consists of only one commit, "document new legacy_auth.pam.* settings ", but is rebased to its proper position relative to PR 486 on which it depends.

To elaborate: 
Pull Requests
   - #486, 
   - #461 (having #486 as a prerequisite), and
   - this one (documenting #461)
   
should be merged in that exact order.
