### PR TITLE
[_510] change permissions to acls

### DIFF
--- a/irods/manager/access_manager.py
+++ b/irods/manager/access_manager.py
@@ -32,11 +32,7 @@ def users_by_ids(session,ids=()):
 
 class AccessManager(Manager):
 
-    def get(self, target, report_raw_acls = False, **kw):
-
-        if not kw.pop('suppress_deprecation_warning',False):
-            warnings.warn('Use of session_obj.permissions is deprecated in v1.1.6',
-                          DeprecationWarning, stacklevel = 2)
+    def get(self, target, report_raw_acls = True, **kw):
 
         if report_raw_acls:
             return self.__get_raw(target, **kw)  # prefer a behavior consistent  with 'ils -A`
@@ -130,10 +126,6 @@ class AccessManager(Manager):
 
 
     def set(self, acl, recursive=False, admin=False, **kw):
-
-        if not kw.pop('suppress_deprecation_warning',False):
-            warnings.warn('Use of session_obj.permissions is deprecated in v1.1.6',
-                          DeprecationWarning, stacklevel = 2)
 
         prefix = 'admin:' if admin else ''
 

--- a/irods/session.py
+++ b/irods/session.py
@@ -65,10 +65,6 @@ class iRODSSession(object):
     def auth_file (self):
         return self._auth_file
 
-    # session.acls will act identically to session.permissions, except its `get'
-    # method has a default parameter of report_raw_acls = True, so it enumerates
-    # ACLs exactly in the manner of "ils -A".
-
     @property
     def available_permissions(self):
         from irods.access import (iRODSAccess,_iRODSAccess_pre_4_3_0)
@@ -123,18 +119,6 @@ class iRODSSession(object):
             _groups = self._groups = _GroupManager(self.user_groups.sess)
         return self._groups
 
-    @property
-    def acls(self):
-        class ACLs(self.permissions.__class__):
-            def set(self, acl, recursive=False, admin=False, **kw):
-                kw['suppress_deprecation_warning'] = True
-                return super(ACLs, self).set(acl, recursive=recursive, admin=admin, **kw)
-            def get(self, target, **kw):
-                kw['suppress_deprecation_warning'] = True
-                return super(ACLs,self).get(target, report_raw_acls = True, **kw)
-        _acls = getattr(self,'_acls',None)
-        if not _acls: _acls = self._acls = ACLs(self.permissions.sess)
-        return _acls
 
     def __init__(self, configure = True, auto_cleanup = True, **kwargs):
         self.pool = None
@@ -150,7 +134,7 @@ class iRODSSession(object):
         self.collections = CollectionManager(self)
         self.data_objects = DataObjectManager(self)
         self.metadata = MetadataManager(self)
-        self.permissions = AccessManager(self)
+        self.acls = AccessManager(self)
         self.users = UserManager(self)
         self.user_groups = GroupManager(self)
         self.resources = ResourceManager(self)

--- a/irods/test/access_test.py
+++ b/irods/test/access_test.py
@@ -264,14 +264,14 @@ class TestAccess(unittest.TestCase):
                            iRODSAccess ('read', self.coll_path, fu.name, self.sess.zone)
                          ]
             for perm in perms1data: self.sess.acls.set ( perm )
-            p1 = self.sess.permissions.get ( self.coll, report_raw_acls = True)
+            p1 = self.sess.acls.get(self.coll)
             self.assertEqual(self.perms_lists_symm_diff( perms1data, p1 ), my_ownership)
             #--data object--
             perms2data = [ iRODSAccess ('write',data.path, fg.name, self.sess.zone),
                            iRODSAccess ('read', data.path, eu.name, self.sess.zone)
                          ]
             for perm in perms2data: self.sess.acls.set ( perm )
-            p2 = self.sess.permissions.get ( data, report_raw_acls = True)
+            p2 = self.sess.acls.get(data)
             self.assertEqual(self.perms_lists_symm_diff( perms2data, p2 ), my_ownership)
         finally:
             ids_for_delete = [ u.id for u in (fu,fg,eu,eg) if u is not None ]


### PR DESCRIPTION
The idea is to remove all traces of `<session>.permissions`, deprecated since v1.1.7