### PR TITLE
[#547] Fix error message for non str metadata in add

### DIFF
--- a/irods/manager/metadata_manager.py
+++ b/irods/manager/metadata_manager.py
@@ -96,8 +96,9 @@ class MetadataManager(Manager):
 
     def add(self, model_cls, path, meta, **opts):
         # Avoid sending request with empty argument(s)
-        if not(len(path) and len(meta.name) and len(meta.value)):
-            raise ValueError('Empty value in ' + repr(meta))
+        if type(meta.name) == 'str' and type(meta.value) == 'str':
+            if not(len(path) and len(meta.name) and len(meta.value)):
+                raise ValueError('Empty value in ' + repr(meta))
 
         resource_type = self._model_class_to_resource_type(model_cls)
         message_body = MetadataRequest(


### PR DESCRIPTION
Looks like checking atr and val type before checking length is enough to see the same error like the set method raises.