### PR TITLE
[#574] Allow for tqdm progress bars to be used

### DIFF
--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -124,7 +124,7 @@ class DataObjectManager(Manager):
                 open_options[kw.DATA_SIZE_KW] = size
 
 
-    def _download(self, obj, local_path, num_threads, **options):
+    def _download(self, obj, local_path, num_threads, pbar, **options):
         """Transfer the contents of a data object to a local file.
 
         Called from get() when a local path is named.
@@ -145,14 +145,17 @@ class DataObjectManager(Manager):
                     f.close()
                     if not self.parallel_get( (obj,o), local_file, num_threads = num_threads,
                                               target_resource_name = options.get(kw.RESC_NAME_KW,''),
-                                              data_open_returned_values = data_open_returned_values_):
+                                              data_open_returned_values = data_open_returned_values_,
+                                              pbar=pbar):
                         raise RuntimeError("parallel get failed")
                 else:
                     for chunk in chunks(o, self.READ_BUFFER_SIZE):
                         f.write(chunk)
+                        if pbar is not None:
+                            pbar.update(len(chunk))
 
 
-    def get(self, path, local_path = None, num_threads = DEFAULT_NUMBER_OF_THREADS, **options):
+    def get(self, path, local_path = None, num_threads = DEFAULT_NUMBER_OF_THREADS, pbar = None, **options):
         """
         Get a reference to the data object at the specified `path'.
 
@@ -163,7 +166,7 @@ class DataObjectManager(Manager):
 
         # TODO: optimize
         if local_path:
-            self._download(path, local_path, num_threads = num_threads, **options)
+            self._download(path, local_path, num_threads = num_threads, pbar=pbar, **options)
 
         query = self.sess.query(DataObject)\
             .filter(DataObject.name == irods_basename(path))\
@@ -180,7 +183,7 @@ class DataObjectManager(Manager):
         return iRODSDataObject(self, parent, results)
 
 
-    def put(self, local_path, irods_path, return_data_object = False, num_threads = DEFAULT_NUMBER_OF_THREADS, **options):
+    def put(self, local_path, irods_path, return_data_object = False, num_threads = DEFAULT_NUMBER_OF_THREADS, pbar = None, **options):
 
         if self.sess.collections.exists(irods_path):
             obj = iRODSCollection.normalize_path(irods_path, os.path.basename(local_path))
@@ -195,7 +198,7 @@ class DataObjectManager(Manager):
                 if not self.parallel_put( local_path, (obj,o), total_bytes = sizelist[0], num_threads = num_threads,
                                           target_resource_name = options.get(kw.RESC_NAME_KW,'') or
                                                                  options.get(kw.DEST_RESC_NAME_KW,''),
-                                          open_options = options ):
+                                          open_options = options, pbar = pbar):
                     raise RuntimeError("parallel put failed")
             else:
                 with self.open(obj, 'w', **options) as o:
@@ -204,6 +207,8 @@ class DataObjectManager(Manager):
                         options[kw.OPR_TYPE_KW] = 1 # PUT_OPR
                     for chunk in chunks(f, self.WRITE_BUFFER_SIZE):
                         o.write(chunk)
+                        if pbar is not None:
+                            pbar.update(len(chunk))
         if kw.ALL_KW in options:
             repl_options = options.copy()
             repl_options[kw.UPDATE_REPL_KW] = ''
@@ -259,7 +264,8 @@ class DataObjectManager(Manager):
                      num_threads = 0,
                      target_resource_name = '',
                      data_open_returned_values = None,
-                     progressQueue = False):
+                     progressQueue = False,
+                     pbar = None):
         """Call into the irods.parallel library for multi-1247 GET.
 
         Called from a session.data_objects.get(...) (via the _download method) on
@@ -270,7 +276,8 @@ class DataObjectManager(Manager):
         return parallel.io_main( self.sess, data_or_path_, parallel.Oper.GET | (parallel.Oper.NONBLOCKING if async_ else 0), file_,
                                  num_threads = num_threads, target_resource_name = target_resource_name,
                                  data_open_returned_values = data_open_returned_values,
-                                 queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0))
+                                 queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0),
+                                 pbar = pbar)
 
     def parallel_put(self,
                      file_ ,
@@ -280,6 +287,7 @@ class DataObjectManager(Manager):
                      num_threads = 0,
                      target_resource_name = '',
                      open_options = {},
+                     pbar = None,
                      progressQueue = False):
         """Call into the irods.parallel library for multi-1247 PUT.
 
@@ -290,6 +298,7 @@ class DataObjectManager(Manager):
         return parallel.io_main( self.sess, data_or_path_, parallel.Oper.PUT | (parallel.Oper.NONBLOCKING if async_ else 0), file_,
                                  num_threads = num_threads, total_bytes = total_bytes,  target_resource_name = target_resource_name,
                                  open_options = open_options,
+                                 pbar = pbar,
                                  queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0)
                                )
 

--- a/irods/parallel.py
+++ b/irods/parallel.py
@@ -223,7 +223,7 @@ def _io_send_bytes_progress (queueObject, item):
 
 COPY_BUF_SIZE = (1024 ** 2) * 4
 
-def _copy_part( src, dst, length, queueObject, debug_info, mgr, pbar):
+def _copy_part( src, dst, length, queueObject, debug_info, mgr, progress_bar):
     """
     The work-horse for performing the copy between file and data object.
 
@@ -240,8 +240,8 @@ def _copy_part( src, dst, length, queueObject, debug_info, mgr, pbar):
         bytecount += buf_len
         accum += buf_len
         if queueObject and accum and _io_send_bytes_progress(queueObject,accum): accum = 0
-        if pbar is not None:
-            pbar.update(buf_len)
+        if progress_bar is not None:
+            progress_bar.update(buf_len)
         if verboseConnection:
             print ("("+debug_info+")",end='',file=sys.stderr)
             sys.stderr.flush()
@@ -303,7 +303,7 @@ class _Multipart_close_manager:
         self.initial_io.close()
 
 
-def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueObject = None, pbar = None):
+def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueObject = None, progress_bar = None):
     """
     Runs in a separate thread to manage the transfer of a range of bytes within the data object.
 
@@ -317,12 +317,12 @@ def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueO
     file_.seek(offset)
     if thread_debug_id == '':  # for more succinct thread identifiers while debugging.
         thread_debug_id = str(threading.currentThread().ident)
-    return ( _copy_part (file_, objHandle, length, queueObject, thread_debug_id, mgr_, pbar) if Operation.isPut()
-        else _copy_part (objHandle, file_, length, queueObject, thread_debug_id, mgr_, pbar) )
+    return ( _copy_part (file_, objHandle, length, queueObject, thread_debug_id, mgr_, progress_bar) if Operation.isPut()
+        else _copy_part (objHandle, file_, length, queueObject, thread_debug_id, mgr_, progress_bar) )
 
 
 def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str, session, fname,
-                           total_size, num_threads, pbar, **extra_options):
+                           total_size, num_threads, progress_bar, **extra_options):
     """Called by _io_main.
 
     Carve up (0,total_size) range into `num_threads` parts and initiate a transfer thread for each one.
@@ -368,7 +368,7 @@ def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str,
         mgr.add_io( Io )
         logger.debug('target_host = %s', Io.raw.session.pool.account.host)
         if File is None: File = gen_file_handle()
-        futures.append(executor.submit( _io_part, Io, byte_range, File, Operation, mgr, str(counter), queueObject, pbar))
+        futures.append(executor.submit( _io_part, Io, byte_range, File, Operation, mgr, str(counter), queueObject, progress_bar))
         counter += 1
         Io = File = None
 
@@ -383,7 +383,7 @@ def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str,
 
 
 
-def io_main( session, Data, opr_, fname, R='', pbar = None, **kwopt):
+def io_main( session, Data, opr_, fname, R='', progress_bar = None, **kwopt):
     """
     The entry point for parallel transfers (multithreaded PUT and GET operations).
 
@@ -470,7 +470,7 @@ def io_main( session, Data, opr_, fname, R='', pbar = None, **kwopt):
     retval = _io_multipart_threaded (Operation, (Data, Io), replica_token, resc_hier, session, fname, total_bytes,
                                      num_threads = num_threads,
                                      _queueLength = queueLength,
-                                     pbar = pbar)
+                                     progress_bar = progress_bar)
 
     # SessionObject.data_objects.parallel_{put,get} will return:
     #   - immediately with an AsyncNotify instance, if Oper.NONBLOCKING flag is used.


### PR DESCRIPTION
Works for both parallel as well as single threaded gets and puts. Some points still to be discussed:

- [ ] Tests: I could write tests with a tqdm progress bar, but that would include an extra dependency for tests.
- [ ] There is already some mechanism for progress bars in the PRC, so for now these two methods are living next to each other. I don't know if that is a problem.
- [ ] I changed `pbar` -> `progress_bar`, which seems more clear for user facing methods.