### PR TITLE
Add progress bar update capability to data transfers in iRODS

### DIFF
--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -124,7 +124,7 @@ class DataObjectManager(Manager):
                 open_options[kw.DATA_SIZE_KW] = size
 
 
-    def _download(self, obj, local_path, num_threads, **options):
+    def _download(self, obj, local_path, num_threads, progress_bar, **options):
         """Transfer the contents of a data object to a local file.
 
         Called from get() when a local path is named.
@@ -145,14 +145,17 @@ class DataObjectManager(Manager):
                     f.close()
                     if not self.parallel_get( (obj,o), local_file, num_threads = num_threads,
                                               target_resource_name = options.get(kw.RESC_NAME_KW,''),
-                                              data_open_returned_values = data_open_returned_values_):
+                                              data_open_returned_values = data_open_returned_values_,
+                                              progress_bar=progress_bar):
                         raise RuntimeError("parallel get failed")
                 else:
                     for chunk in chunks(o, self.READ_BUFFER_SIZE):
                         f.write(chunk)
+                        if progress_bar is not None:
+                            progress_bar.update(len(chunk))
 
 
-    def get(self, path, local_path = None, num_threads = DEFAULT_NUMBER_OF_THREADS, **options):
+    def get(self, path, local_path = None, num_threads = DEFAULT_NUMBER_OF_THREADS, progress_bar = None, **options):
         """
         Get a reference to the data object at the specified `path'.
 
@@ -163,7 +166,7 @@ class DataObjectManager(Manager):
 
         # TODO: optimize
         if local_path:
-            self._download(path, local_path, num_threads = num_threads, **options)
+            self._download(path, local_path, num_threads = num_threads, progress_bar=progress_bar, **options)
 
         query = self.sess.query(DataObject)\
             .filter(DataObject.name == irods_basename(path))\
@@ -180,7 +183,7 @@ class DataObjectManager(Manager):
         return iRODSDataObject(self, parent, results)
 
 
-    def put(self, local_path, irods_path, return_data_object = False, num_threads = DEFAULT_NUMBER_OF_THREADS, **options):
+    def put(self, local_path, irods_path, return_data_object = False, num_threads = DEFAULT_NUMBER_OF_THREADS, progress_bar = None, **options):
 
         if self.sess.collections.exists(irods_path):
             obj = iRODSCollection.normalize_path(irods_path, os.path.basename(local_path))
@@ -195,7 +198,7 @@ class DataObjectManager(Manager):
                 if not self.parallel_put( local_path, (obj,o), total_bytes = sizelist[0], num_threads = num_threads,
                                           target_resource_name = options.get(kw.RESC_NAME_KW,'') or
                                                                  options.get(kw.DEST_RESC_NAME_KW,''),
-                                          open_options = options ):
+                                          open_options = options, progress_bar = progress_bar):
                     raise RuntimeError("parallel put failed")
             else:
                 with self.open(obj, 'w', **options) as o:
@@ -204,6 +207,8 @@ class DataObjectManager(Manager):
                         options[kw.OPR_TYPE_KW] = 1 # PUT_OPR
                     for chunk in chunks(f, self.WRITE_BUFFER_SIZE):
                         o.write(chunk)
+                        if progress_bar is not None:
+                            progress_bar.update(len(chunk))
         if kw.ALL_KW in options:
             repl_options = options.copy()
             repl_options[kw.UPDATE_REPL_KW] = ''
@@ -259,7 +264,8 @@ class DataObjectManager(Manager):
                      num_threads = 0,
                      target_resource_name = '',
                      data_open_returned_values = None,
-                     progressQueue = False):
+                     progressQueue = False,
+                     progress_bar = None):
         """Call into the irods.parallel library for multi-1247 GET.
 
         Called from a session.data_objects.get(...) (via the _download method) on
@@ -270,7 +276,8 @@ class DataObjectManager(Manager):
         return parallel.io_main( self.sess, data_or_path_, parallel.Oper.GET | (parallel.Oper.NONBLOCKING if async_ else 0), file_,
                                  num_threads = num_threads, target_resource_name = target_resource_name,
                                  data_open_returned_values = data_open_returned_values,
-                                 queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0))
+                                 queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0),
+                                 progress_bar = progress_bar)
 
     def parallel_put(self,
                      file_ ,
@@ -280,6 +287,7 @@ class DataObjectManager(Manager):
                      num_threads = 0,
                      target_resource_name = '',
                      open_options = {},
+                     progress_bar = None,
                      progressQueue = False):
         """Call into the irods.parallel library for multi-1247 PUT.
 
@@ -290,6 +298,7 @@ class DataObjectManager(Manager):
         return parallel.io_main( self.sess, data_or_path_, parallel.Oper.PUT | (parallel.Oper.NONBLOCKING if async_ else 0), file_,
                                  num_threads = num_threads, total_bytes = total_bytes,  target_resource_name = target_resource_name,
                                  open_options = open_options,
+                                 progress_bar = progress_bar,
                                  queueLength = (DEFAULT_QUEUE_DEPTH if progressQueue else 0)
                                )
 

--- a/irods/parallel.py
+++ b/irods/parallel.py
@@ -223,7 +223,7 @@ def _io_send_bytes_progress (queueObject, item):
 
 COPY_BUF_SIZE = (1024 ** 2) * 4
 
-def _copy_part( src, dst, length, queueObject, debug_info, mgr):
+def _copy_part( src, dst, length, queueObject, debug_info, mgr, progress_bar):
     """
     The work-horse for performing the copy between file and data object.
 
@@ -240,6 +240,8 @@ def _copy_part( src, dst, length, queueObject, debug_info, mgr):
         bytecount += buf_len
         accum += buf_len
         if queueObject and accum and _io_send_bytes_progress(queueObject,accum): accum = 0
+        if progress_bar is not None:
+            progress_bar.update(buf_len)
         if verboseConnection:
             print ("("+debug_info+")",end='',file=sys.stderr)
             sys.stderr.flush()
@@ -301,7 +303,7 @@ class _Multipart_close_manager:
         self.initial_io.close()
 
 
-def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueObject = None ):
+def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueObject = None, progress_bar = None):
     """
     Runs in a separate thread to manage the transfer of a range of bytes within the data object.
 
@@ -315,12 +317,12 @@ def _io_part (objHandle, range_, file_, opr_, mgr_, thread_debug_id = '', queueO
     file_.seek(offset)
     if thread_debug_id == '':  # for more succinct thread identifiers while debugging.
         thread_debug_id = str(threading.currentThread().ident)
-    return ( _copy_part (file_, objHandle, length, queueObject, thread_debug_id, mgr_) if Operation.isPut()
-        else _copy_part (objHandle, file_, length, queueObject, thread_debug_id, mgr_) )
+    return ( _copy_part (file_, objHandle, length, queueObject, thread_debug_id, mgr_, progress_bar) if Operation.isPut()
+        else _copy_part (objHandle, file_, length, queueObject, thread_debug_id, mgr_, progress_bar) )
 
 
 def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str, session, fname,
-                           total_size, num_threads, **extra_options):
+                           total_size, num_threads, progress_bar, **extra_options):
     """Called by _io_main.
 
     Carve up (0,total_size) range into `num_threads` parts and initiate a transfer thread for each one.
@@ -366,7 +368,7 @@ def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str,
         mgr.add_io( Io )
         logger.debug(u'target_host = %s', Io.raw.session.pool.account.host)
         if File is None: File = gen_file_handle()
-        futures.append(executor.submit( _io_part, Io, byte_range, File, Operation, mgr, str(counter), queueObject))
+        futures.append(executor.submit( _io_part, Io, byte_range, File, Operation, mgr, str(counter), queueObject, progress_bar))
         counter += 1
         Io = File = None
 
@@ -381,7 +383,7 @@ def _io_multipart_threaded(operation_ , dataObj_and_IO, replica_token, hier_str,
 
 
 
-def io_main( session, Data, opr_, fname, R='', **kwopt):
+def io_main( session, Data, opr_, fname, R='', progress_bar = None, **kwopt):
     """
     The entry point for parallel transfers (multithreaded PUT and GET operations).
 
@@ -395,7 +397,6 @@ def io_main( session, Data, opr_, fname, R='', **kwopt):
     Operation = Oper(opr_)
     d_path = None
     Io = None
-
     if isinstance(Data,tuple):
         (Data, Io) = Data[:2]
 
@@ -468,7 +469,8 @@ def io_main( session, Data, opr_, fname, R='', **kwopt):
     queueLength = kwopt.get('queueLength',0)
     retval = _io_multipart_threaded (Operation, (Data, Io), replica_token, resc_hier, session, fname, total_bytes,
                                      num_threads = num_threads,
-                                     _queueLength = queueLength)
+                                     _queueLength = queueLength,
+                                     progress_bar = progress_bar)
 
     # SessionObject.data_objects.parallel_{put,get} will return:
     #   - immediately with an AsyncNotify instance, if Oper.NONBLOCKING flag is used.

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -18,9 +18,20 @@ import stat
 import string
 import sys
 import subprocess
+import threading
 import time
 import unittest
 import xml.etree.ElementTree
+
+try:
+    import tqdm
+except ImportError:
+    tqdm = None
+
+try:
+    import progressbar
+except ImportError:
+    progressbar = None
 
 ip_pattern = re.compile(r'(\d+)\.(\d+)\.(\d+)\.(\d+)$')
 localhost_with_optional_domain_pattern = re.compile('localhost(\.\S\S*)?$')
@@ -88,7 +99,6 @@ def make_ufs_resc_in_tmpdir(session, base_name, allow_local = False, client_vaul
 
 
 class TestDataObjOps(unittest.TestCase):
-
 
     from irods.test.helpers import (create_simple_resc)
 
@@ -2128,6 +2138,164 @@ class TestDataObjOps(unittest.TestCase):
                     if self.sess.data_objects.exists(data_path):
                         self.sess.data_objects.unlink(data_path, force = True)
 
+    @unittest.skipIf(progressbar is None, "progressbar is not installed")
+    def test_progressbar_style_of_pbar_without_registering__issue_574(self):
+        # As this test demonstrates, we can always just register an update wrapper for an object rather than the object or its update method directly.
+        # This is good if the progressbar instance is not inherently threadsafe or unable to be referred to by a weak reference.
+        from irods.manager.data_object_manager import register_update_instance
+
+        class wrapper:
+            def __init__(self,pbar):
+                self.lock = threading.Lock()
+                self.total = 0
+                self.pbar = pbar
+                pbar.start()
+
+            def update(self,n):
+                with self.lock:
+                    self.total += n
+                    self.pbar.update(self.total)
+
+            @property
+            def value(self):
+                try: 
+                    return self.pbar.value
+                except AttributeError:
+                    return self.pbar.currval
+
+        LEN = 1024**2*40
+        content = b'_'*LEN
+
+        progress_bar = progressbar.ProgressBar(maxval=len(content))
+        wrapped = wrapper(progress_bar)
+
+        register_update_instance(wrapped, wrapped.update)
+
+        self._run_pbars_for_parallel_io(content, [wrapped])
+        self.assertEqual(wrapped.value, LEN)
+
+    @unittest.skipIf(progressbar is None, "progressbar is not installed")
+    def test_progressbar_style_of_pbar_by_registering_type__issue_574(self):
+        # In this test, registering the instance type allows us to use the progressbar instance in the updatables list
+        from irods.manager.data_object_manager import (register_update_type, unregister_update_type)
+
+        # This is the ProgressBar from either of the following sources:
+        #    - https://pypi.org/project/progressbar/
+        #    - https://pypi.org/project/progressbar2/
+        # Wrapping the ProgressBar instances is useful in the case of both of the above libraries,
+        # due to their instances being callable - which confuses our methodology for managing registered objects - or,
+        # in the former case, being unusable as weak references.
+
+        class ProgressBar_wrapper:
+            def start(self,*x):
+                return self.pbar.start(*x)
+            def update(self,*x):
+                return self.pbar.update(*x)
+            @property
+            def value(self):
+                try: 
+                    return self.pbar.value
+                except AttributeError:
+                    return self.pbar.currval
+            def __init__(self,*args,**kw):
+                self.pbar = progressbar.ProgressBar(*args,**kw)
+
+        def adapt_ProgressBar(pbar):
+            total = [0]
+            l = threading.Lock()
+            # This extra step is necessary for progressbar / progressbar2 instances:
+            pbar.start()
+            # Here's the actual updating callable that will be returned for the current pbar instance (also part of the closure)
+            # and then registered for update during the data transfer.
+            def _update(n):
+                with l:
+                    # 'total' was made a list-of-single-integer to make it modifiable in Python2 clients. (We could have made it
+                    # a bare integer, declared as "nonlocal total" to scope it properly, and this would have worked in Python3.
+                    # Note, too: this type of progress bar requires a cumulative sum as its argument to the update method.
+                    total[0] += n
+                    pbar.update(total[0])
+            return _update
+
+        try:
+            register_update_type(ProgressBar_wrapper, adapt_ProgressBar)
+
+            LEN = 1024**2*40
+            content = b'_'*LEN
+            pbar = ProgressBar_wrapper(maxval=len(content))
+            self._run_pbars_for_parallel_io(content, [pbar])
+            self.assertEqual(pbar.value, LEN)
+
+        finally:
+            unregister_update_type(ProgressBar_wrapper)
+
+    @unittest.skipIf(tqdm is None, "tqdm is not installed")
+    def test_passing_multiple_tqdm_instances_to_be_updated__issue_574(self):
+        from irods.manager.data_object_manager import (register_update_type, unregister_update_type)
+
+        def adapt_tqdm(pbar):
+            l = threading.Lock()
+            def _update(n):
+                with l:
+                    pbar.update(n)
+            return _update
+
+        try:
+            register_update_type(tqdm.tqdm, adapt_tqdm)
+
+            LEN = 1024**2*40
+            content = b'_'*LEN
+            tqdm_1 = tqdm.tqdm(total=len(content))
+            tqdm_2 = tqdm.tqdm(total=len(content))
+            self._run_pbars_for_parallel_io(content, [tqdm_1,tqdm_2]) # The bare the bound instance method itself, ie tqdm_2.update,
+                                                                      # could be passed in, if we knew it to be thread-safe.
+            self.assertEqual(tqdm_1.n, LEN)
+            self.assertEqual(tqdm_2.n, LEN)
+
+        finally:
+            unregister_update_type(tqdm.tqdm)
+
+    def _run_pbars_for_parallel_io(self, file_content, list_of_progress_bars_and_update_callbacks):
+        # Helper method for issue #574 tests.
+        Data = self.sess.data_objects
+        logical_path = ''
+        try:
+            with NamedTemporaryFile() as f:
+                f.write(file_content) # large file for a parallel put
+                f.flush()
+                logical_path = '{}/{}'.format(self.coll_path,os.path.basename(f.name))
+                Data.put(f.name, logical_path, updatables = list_of_progress_bars_and_update_callbacks)
+        finally:
+            if logical_path and Data.exists(logical_path):
+                Data.unlink(logical_path, force = True)
+
+    def test_mock_progress_bar_for_parallel_io__issue_574(self):
+
+        # Simulated progress bar in the style of TQDM
+        class mock_progress_bar:
+            def percent_done(self): return 100.0 * self.i / self.total
+            def __init__(self, total):
+                self.i = 0
+                self.total = total
+            def update(self,n):
+                self.i += n
+
+        def thread_safe(update_fn):
+            l = threading.Lock()
+            def _update(n):
+                with l:
+                    update_fn(n)
+            return _update
+
+        FILE_LENGTH = 1024**2 * 40
+        pbar = mock_progress_bar(total = FILE_LENGTH)
+
+        with NamedTemporaryFile() as f:
+            f.write(b'_'*FILE_LENGTH) # large file for a parallel put
+            f.flush()
+            logical_path = '{}/{}'.format(self.coll_path,os.path.basename(f.name))
+            self.sess.data_objects.put(f.name, logical_path, updatables = [thread_safe(pbar.update)])
+
+        self.assertEqual(pbar.percent_done(), 100)
 
 if __name__ == '__main__':
     # let the tests find the parent irods lib


### PR DESCRIPTION
Designed in such as way as to be foreseeably generic and /or adaptable to multiple progress bar libraries.  `progressbar` and `tqdm` are  demonstrated as compatible.

This PR may end up supplanting https://github.com/irods/python-irodsclient/pull/575