### PR TITLE
[#584] load settings from environment without a config file present

### DIFF
--- a/irods/client_configuration/__init__.py
+++ b/irods/client_configuration/__init__.py
@@ -327,21 +327,30 @@ def load(root = None, file = '', failure_modes = (), verify_only = False, loggin
             _load_config_line(root, match.group('key'), match.group('value'))
 
         if use_environment_variables:
-            for key, variable in _calculate_overriding_environment_variables().items():
-                value = os.environ.get(variable)
-                if value is not None:
-                    _load_config_line(root, key, value)
+            _load_settings_from_environment(root)
+
     finally:
         if _file:
             _file.close()
 
+
 default_config_dict = {}
+
+def _load_settings_from_environment(root = None):
+    if root is None:
+        root = sys.modules[__name__]
+    for key, variable in _calculate_overriding_environment_variables().items():
+        value = os.environ.get(variable)
+        if value is not None:
+            _load_config_line(root, key, value)
 
 def preserve_defaults():
     default_config_dict.update((k,copy.deepcopy(v)) for k,v in globals().items() if isinstance(v,iRODSConfiguration))
 
 def autoload(_file_to_load):
-    if _file_to_load is not None:
+    if _file_to_load is None:
+        _load_settings_from_environment()
+    else:
         load(file = _file_to_load, use_environment_variables = True)
 
 def new_default_config():

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -2024,6 +2024,20 @@ class TestDataObjOps(unittest.TestCase):
                     config.load(**load_logging_options)
                     self.assertTrue(config.data_objects.auto_close, RANDOM_VALUE - i - 1)
 
+    @unittest.skipIf(os.environ.get("PYTHON_IRODSCLIENT_CONFIGURATION_PATH",None) is not None,"test will not run if configuration file set.")
+    def test_setting_xml_parser_choice_by_environment_only__issue_584(self):
+        program = os.path.join(test_modules.__path__[0], 'test_xml_parser.py')
+        xml_parser_control_var = 'PYTHON_IRODSCLIENT_CONFIG__CONNECTIONS__XML_PARSER_DEFAULT'
+        with helpers.environment_variable_backed_up(xml_parser_control_var):
+            for alternate_setting in ('QUASI_XML', 'STANDARD_XML', 'SECURE_XML'):
+                # Set xml parser for the process to be spawned.
+                os.environ[xml_parser_control_var]="'{alternate_setting}'".format(**locals())
+                # Run a simple script that imports PRC and prints which XML parser is the active default.
+                p = subprocess.Popen([sys.executable,program], stdout=subprocess.PIPE)
+                parser_id = p.communicate()[0].decode().strip()
+                # Assert the printed result is as expected.
+                self.assertEqual(parser_id, alternate_setting)
+
     def test_append_mode_will_append_to_data_object__issue_495(self):
         append_string = b'to_be_written'.lower()
         reverse_bytes = lambda s: ''.join(reversed(s)) if six.PY2 else bytes(reversed(s))

--- a/irods/test/modules/test_xml_parser.py
+++ b/irods/test/modules/test_xml_parser.py
@@ -1,0 +1,4 @@
+import irods
+#  Used in test of:
+#    irods.test.data_obj_test.TestDataObjOps.test_setting_xml_parser_choice_by_environment_only__issue_584
+print(irods.client_configuration.connections.xml_parser_default)


### PR DESCRIPTION
See [issue description](https://github.com/irods/python-irodsclient/issues/584).  Basically this change means that you won't have to declare a config file path in the environment  (even if that value is null length, denoting the default path of `~/.python_irodsclient`) in order to get the environmental overrides to work.
