### PR TITLE
[#606] attach server response message to exception

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,6 +732,30 @@ from an object:
 ...     Object.metadata.apply_atomic_operations( *[AVUOperation(operation='remove', avu=i) for i in avus_on_Object] )
 ```
 
+Extracting JSON encoded server information in case of error
+-----------------------------------------------------------
+
+Some server apis, including atomic metadata and replica truncation, can fail for various reasons and generate an
+exception.  In these cases the message object returned from the server is made available in the 'server_msg' attribute
+of the iRODSException object.
+
+This enables an approach like the following, which logs server information possibly underlying the error that was evoked:
+
+```python
+    try:
+        Object.metadata.apply_atomic_operations( ops )
+        # or:
+        DataObject.replica_truncate( size )
+    except iRODSException as exc:
+        log.error('Server API call failure. Traceback = %r ; iRODS Server info = %r',
+            traceback.extract_tb(sys.exc_info()[2]),
+            exc.server_msg.get_json_encoded_struct())
+```
+
+For `DataObject.replica_truncate(...)`, note that exc.server_msg.get_json_encoded_struct() can be used in the exception-handling
+code path to retrieve the same information that would have been routinely returned from the truncate call itself, had it actually
+completed without error.
+
 Special Characters
 ------------------
 

--- a/irods/connection.py
+++ b/irods/connection.py
@@ -149,7 +149,9 @@ class Connection(object):
             except TypeError:
                 err_msg = None
             if nominal_code(msg.int_info) not in acceptable_codes:
-                raise get_exception_by_code(msg.int_info, err_msg)
+                exc = get_exception_by_code(msg.int_info, err_msg)
+                exc.server_msg = msg
+                raise exc
         return msg
 
     def recv_into(self, buffer, **options):


### PR DESCRIPTION
Includes test with `atomic_metadata`.
Other APIs that could use this feature include `replica_truncate` and `atomic_apply_acls`