### PR TITLE
Fix an import in the tests that doesn’t seem to work as intended

### DIFF
--- a/irods/test/resource_test.py
+++ b/irods/test/resource_test.py
@@ -11,7 +11,8 @@ import irods.test.helpers as helpers
 
 class TestResource(unittest.TestCase):
 
-    from helpers import create_simple_resc_hierarchy, create_simple_resc
+    create_simple_resc_hierarchy = helpers.create_simple_resc_hierarchy
+    create_simple_resc = helpers.create_simple_resc
 
     def setUp(self):
         self.sess = helpers.make_session()


### PR DESCRIPTION
I’m considering packaging this in Fedora Linux. I don’t have the ability to test this with a real iRODS grid, so I’m using an import-only “smoke test” as a sanity check. I found that `irods.test.resource_test` fails to import, at least on Python 3.13, with an `ImportError` like the following:

```
  File "/builddir/build/BUILD/python-python-irodsclient-2.1.0-build/BUILDROOT/usr/lib/python3.13/site-packages/irods/test/resource_test.py", line 14, in TestResource
    from helpers import create_simple_resc_hierarchy, create_simple_resc
ModuleNotFoundError: No module named 'helpers'
```

Maybe this works on older Python interpreters – I’m not sure – but this PR fixes the problem in a way that should be compatible with *all* Pythons.