### PR TITLE
[_3] remove Infinity from test as it is now a valid connection_timeou…

### DIFF
--- a/irods/test/connection_test.py
+++ b/irods/test/connection_test.py
@@ -156,7 +156,7 @@ class TestConnections(unittest.TestCase):
         self.assertEqual(sess.connection_timeout, DESIRED_TIMEOUT)
 
         # Test that bad timeout values are met with an exception.
-        for value in (float('NaN'), float('Inf'), -float('Inf'), -1, 0, 0.0, "banana"):
+        for value in (float('NaN'), -float('Inf'), -1, 0, 0.0, "banana"):
             with self.assertRaises(ValueError):
                 sess.connection_timeout = value
 


### PR DESCRIPTION
Affects `irods.test.connection_test.TestConnections.test_assigning_session_connection_timeout_to_invalid_values__issue_569`, which assumed Iinfinity was not a valid value for the session timeout and was therefore failing of late.  (As of the impending v2.2.0 release, it is now valid and resolves to the maximum value for timeout.)

This new commit allows the test to pass:

[_3] remove Infinity from test as it is now a valid connection_timeout value
