### PR TITLE
[#480] Remove Python2 compatibility from code base

### DIFF
--- a/irods/__init__.py
+++ b/irods/__init__.py
@@ -1,3 +1,12 @@
+import sys
+
+minimum_compatible_python = (3,6)
+
+if sys.version_info < minimum_compatible_python:
+    to_dotted_string = lambda version_tuple: '.'.join(str(_) for _ in version_tuple)
+    version_message = "This library is only supported on Python {} and above.".format(to_dotted_string(minimum_compatible_python))
+    raise RuntimeError(version_message)
+
 from .version import __version__, version_as_tuple, version_as_string
 
 import logging

--- a/irods/access.py
+++ b/irods/access.py
@@ -1,6 +1,5 @@
 import collections
 import copy
-import six
 from irods.collection import iRODSCollection
 from irods.data_object import iRODSDataObject
 from irods.path import iRODSPath
@@ -11,7 +10,7 @@ class _Access_LookupMeta(type):
     def values(self): return list(self.codes[k] for k in self.codes.keys())
     def items(self): return list(zip(self.keys(),self.values()))
 
-class iRODSAccess(six.with_metaclass(_Access_LookupMeta)):
+class iRODSAccess(metaclass = _Access_LookupMeta):
 
     @classmethod
     def to_int(cls,key):
@@ -101,9 +100,7 @@ class iRODSAccess(six.with_metaclass(_Access_LookupMeta)):
         object_dict = vars(self)
         access_name = self.access_name.replace(' ','_')
         user_type_hint = ("({user_type})" if object_dict.get('user_type') is not None else "").format(**object_dict)
-        return "<iRODSAccess {0} {path} {user_name}{1} {user_zone}>".format(access_name,
-                                                                            user_type_hint,
-                                                                            **object_dict)
+        return f"<iRODSAccess {access_name} {self.path} {self.user_name}{user_type_hint} {self.user_zone}>"
 
 class _iRODSAccess_pre_4_3_0(iRODSAccess):
     codes = collections.OrderedDict(

--- a/irods/account.py
+++ b/irods/account.py
@@ -1,6 +1,6 @@
 from irods import derived_auth_filename
 
-class iRODSAccount(object):
+class iRODSAccount:
 
     @property
     def derived_auth_file(self):

--- a/irods/auth/__init__.py
+++ b/irods/auth/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 __all__ = [ 'pam_password', 'native' ]
 
 AUTH_PLUGIN_PACKAGE = 'irods.auth'

--- a/irods/client_configuration/__init__.py
+++ b/irods/client_configuration/__init__.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import ast
 import collections
 import contextlib
@@ -7,7 +6,6 @@ import io
 import logging
 import os
 import re
-import six
 import sys
 import types
 
@@ -16,7 +14,7 @@ from .. import DEFAULT_CONFIG_PATH
 
 logger = logging.Logger(__name__)
 
-class iRODSConfiguration(object):
+class iRODSConfiguration:
     __slots__ = ()
 
 def getter(category, setting):
@@ -39,7 +37,7 @@ class iRODSConfigAliasMetaclass(type):
                 isinstance(v,property) and v.fset is not None)
         return cls
 
-class ConnectionsProperties(six.with_metaclass(iRODSConfigAliasMetaclass,iRODSConfiguration)):
+class ConnectionsProperties(iRODSConfiguration, metaclass = iRODSConfigAliasMetaclass):
     @property
     def xml_parser_default(self):
         from irods.message import get_default_XML_by_name

--- a/irods/collection.py
+++ b/irods/collection.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import itertools
 import operator
 
@@ -11,7 +10,7 @@ def _first_char( *Strings ):
         if s: return s[0]
     return ''
 
-class iRODSCollection(object):
+class iRODSCollection:
 
     class AbsolutePathRequired(Exception):
         """Exception raised by iRODSCollection.normalize_path.
@@ -108,4 +107,4 @@ class iRODSCollection(object):
         return irods.path.iRODSPath(*paths, absolute = absolute)
 
     def __repr__(self):
-        return "<iRODSCollection {id} {name}>".format(id = self.id, name = self.name.encode('utf-8'))
+        return f"<iRODSCollection {self.id} {self.name}>"

--- a/irods/column.py
+++ b/irods/column.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
-import six
 from datetime import datetime
 from calendar import timegm
 
 
-class QueryKey(object):
+class QueryKey:
 
     def __init__(self, column_type):
         self.column_type = column_type
@@ -28,7 +26,7 @@ class QueryKey(object):
         return Criterion('>=', self, other)
 
 
-class Criterion(object):
+class Criterion:
 
     def __init__(self, op, query_key, value):
         self.op = op
@@ -105,7 +103,7 @@ class Keyword(QueryKey):
 
 
 # consider renaming columnType
-class ColumnType(object):
+class ColumnType:
 
     @staticmethod
     def to_python(string):
@@ -137,11 +135,11 @@ class String(ColumnType):
     def to_irods(data):
         try:
             # Convert to Unicode string (aka decode)
-            data = six.text_type(data, 'utf-8', 'replace')
+            data = str(data, 'utf-8', 'replace')
         except TypeError:
             # Some strings are already Unicode so they do not need decoding
             pass
-        return u"'{}'".format(data)
+        return "'{}'".format(data)
 
 
 class DateTime(ColumnType):

--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -1,8 +1,6 @@
-from __future__ import absolute_import
 import io
 import sys
 import logging
-import six
 import os
 import ast
 
@@ -26,7 +24,7 @@ def irods_basename(path):
     return path.rsplit('/', 1)[1]
 
 
-class iRODSReplica(object):
+class iRODSReplica:
 
     def __init__(self, number, status, resource_name, path, resc_hier, **kwargs):
         self.number = number
@@ -46,13 +44,13 @@ class iRODSReplica(object):
         )
 
 
-class iRODSDataObject(object):
+class iRODSDataObject:
 
     def __init__(self, manager, parent=None, results=None):
         self.manager = manager
         if parent and results:
             self.collection = parent
-            for attr, value in six.iteritems(DataObject.__dict__):
+            for attr, value in DataObject.__dict__.items():
                 if not attr.startswith('_'):
                     try:
                         setattr(self, attr, results[0][value])
@@ -80,7 +78,7 @@ class iRODSDataObject(object):
 
 
     def __repr__(self):
-        return "<iRODSDataObject {id} {name}>".format(**vars(self))
+        return f"<iRODSDataObject {self.id} {self.name}>"
 
     @property
     def metadata(self):

--- a/irods/exception.py
+++ b/irods/exception.py
@@ -2,12 +2,9 @@
 # s/\(\w\+\)\s\+\(-\d\+\)/class \1(SystemException):\r    code = \2/g
 
 
-from __future__ import absolute_import
-from __future__ import print_function
 import errno
 import numbers
 import os
-import six
 import sys
 
 
@@ -114,7 +111,7 @@ class Errno:
         return self.int_code
 
 
-class iRODSException(six.with_metaclass(iRODSExceptionMeta, Exception)):
+class iRODSException(Exception, metaclass = iRODSExceptionMeta):
     """An exception that originates from a server error.
        Exception classes that are derived from this base and represent a concrete error, should
        store a unique error code (X*1000) in their 'code' attribute, where X < 0.

--- a/irods/genquery2.py
+++ b/irods/genquery2.py
@@ -5,7 +5,7 @@ from irods.exception import OperationNotSupported
 from irods.message import GenQuery2Request, STR_PI, iRODSMessage
 
 
-class GenQuery2(object):
+class GenQuery2:
     """Interface to the GenQuery2 API
 
        This class provides an interface to the GenQuery2 API, an experimental

--- a/irods/manager/__init__.py
+++ b/irods/manager/__init__.py
@@ -1,4 +1,4 @@
-class Manager(object):
+class Manager:
 
     __server_version = ()
 

--- a/irods/manager/access_manager.py
+++ b/irods/manager/access_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from os.path import basename, dirname
 
 from irods.manager import Manager
@@ -12,7 +11,6 @@ from irods.access import iRODSAccess
 from irods.column import In
 from irods.user import iRODSUser
 
-import six
 import logging
 import warnings
 
@@ -22,7 +20,7 @@ def users_by_ids(session,ids=()):
     try:
         ids=list(iter(ids))
     except TypeError:
-        if type(ids) in (str,) + six.integer_types: ids=int(ids)
+        if type(ids) in (str,int): ids=int(ids)
         else: raise
     cond = () if not ids \
            else (In(User.id,list(map(int,ids))),) if len(ids)>1 \
@@ -138,7 +136,7 @@ class AccessManager(Manager):
         acl = acl.copy(decanonicalize = True)
         message_body = ModAclRequest(
             recursiveFlag=int(recursive),
-            accessLevel='{prefix}{access_name}'.format(prefix=prefix, **vars(acl)),
+            accessLevel=f'{prefix}{acl.access_name}',
             userName=userName_,
             zone=zone_,
             path=acl.path

--- a/irods/manager/collection_manager.py
+++ b/irods/manager/collection_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from irods.models import Collection, DataObject
 from irods.manager import Manager
 from irods.manager._internal import _api_impl

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -1,11 +1,9 @@
-from __future__ import absolute_import
 import ast
 import collections
 import io
 import json
 import logging
 import os
-import six
 import weakref
 from irods.models import DataObject, Collection
 from irods.manager import Manager
@@ -176,13 +174,13 @@ class DataObjectManager(Manager):
                 else:
                     pos = obj_sz.tell()
                     size = obj_sz.seek(0,os.SEEK_END)
-                    if not isinstance(size,six.integer_types):
+                    if not isinstance(size,int):
                         size = obj_sz.tell()
                     obj_sz.seek(pos,os.SEEK_SET)
                 if isinstance(measured_obj_size,list):
                     measured_obj_size[:] = [size]
                 return size > MAXIMUM_SINGLE_THREADED_TRANSFER_SIZE
-            elif isinstance(obj_sz,six.integer_types):
+            elif isinstance(obj_sz,int):
                 return obj_sz > MAXIMUM_SINGLE_THREADED_TRANSFER_SIZE
             message = 'obj_sz of {obj_sz!r} is neither an integer nor a seekable object'.format(**locals())
             raise RuntimeError(message)
@@ -507,7 +505,7 @@ class DataObjectManager(Manager):
                 returned_values['session'] = directed_sess
                 conn.release()
                 conn = directed_sess.pool.get_connection()
-                logger.debug(u'redirect_to_host = %s', redirected_host)
+                logger.debug('redirect_to_host = %s', redirected_host)
 
         # Restore RESC HIER for DATA_OBJ_OPEN call
         if requested_hierarchy is not None:

--- a/irods/manager/metadata_manager.py
+++ b/irods/manager/metadata_manager.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-from __future__ import absolute_import
 import logging
 import copy
 from os.path import dirname, basename

--- a/irods/manager/resource_manager.py
+++ b/irods/manager/resource_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from irods.models import Resource
 from irods.manager import Manager
 from irods.message import GeneralAdminRequest, iRODSMessage

--- a/irods/manager/user_manager.py
+++ b/irods/manager/user_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 import os
 import warnings
@@ -76,7 +75,7 @@ class UserManager(Manager):
             "add",
             "user",
             user_name if not user_zone or user_zone == self.sess.zone \
-                      else "{}#{}".format(user_name,user_zone),
+                      else f"{user_name}#{user_zone}",
             user_type,
             user_zone,
             auth_str
@@ -189,8 +188,8 @@ class UserManager(Manager):
                     with open(auth_file) as f:
                         stored_pw = obf.decode(f.read())
                     if stored_pw != old_value:
-                        message = "Not changing contents of '{}' - "\
-                                  "stored password is non-native or false match to old password".format(auth_file)
+                        message = f"Not changing contents of '{auth_file}' - "\
+                                  "stored password is non-native or false match to old password"
                         raise UserManager.EnvStoredPasswordNotEdited(message)
                     with open(auth_file,'w') as f:
                         f.write(obf.encode(new_value))

--- a/irods/manager/zone_manager.py
+++ b/irods/manager/zone_manager.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import logging
 
 from irods.models import Zone

--- a/irods/message/message.py
+++ b/irods/message/message.py
@@ -1,7 +1,5 @@
 # http://askawizard.blogspot.com/2008/10/ordered-properties-python-saga-part-5.html
-from __future__ import absolute_import
 from irods.message.ordered import OrderedMetaclass, OrderedClass
-import six
 
 
 class MessageMetaclass(OrderedMetaclass):
@@ -12,7 +10,7 @@ class MessageMetaclass(OrderedMetaclass):
             prop.dub(name)
 
 
-class Message(six.with_metaclass(MessageMetaclass, OrderedClass)):
+class Message(OrderedClass, metaclass = MessageMetaclass):
 
     def __init__(self, *args, **kwargs):
         super(Message, self).__init__()

--- a/irods/message/ordered.py
+++ b/irods/message/ordered.py
@@ -1,8 +1,6 @@
 # Ordered property classes stolen from Kris Kowal of Ask a Wizard
 # http://askawizard.blogspot.com/2008/10/ordered-properties-python-saga-part-5.html
-from __future__ import absolute_import
 from itertools import count
-import six
 
 try:
     next_counter = count().__next__
@@ -10,7 +8,7 @@ except AttributeError:
     next_counter = count().next
 
 
-class OrderedProperty(object):
+class OrderedProperty:
 
     def __init__(self, *args, **kws):
         self._creation_counter = next_counter()
@@ -34,5 +32,5 @@ class OrderedMetaclass(type):
         )
 
 
-class OrderedClass(six.with_metaclass(OrderedMetaclass, object)):
+class OrderedClass(metaclass = OrderedMetaclass):
     pass

--- a/irods/message/property_types.py
+++ b/irods/message/property_types.py
@@ -1,12 +1,7 @@
-from __future__ import absolute_import
 from base64 import b64encode, b64decode
 
 from irods.message.ordered import OrderedProperty
-import six
-if six.PY3:
-    from html import escape
-else:
-    from cgi import escape
+from html import escape
 
 class MessageProperty(OrderedProperty):
 
@@ -24,7 +19,7 @@ class MessageProperty(OrderedProperty):
         values = []
         values.append("<%s>" % self.name)
         my_value = self.format(value)
-        if six.PY3 and isinstance(my_value, bytes):
+        if isinstance(my_value, bytes):
             my_value = my_value.decode("utf-8")
         values.append(my_value)
         values.append("</%s>" % self.name)
@@ -61,18 +56,11 @@ class BinaryProperty(MessageProperty):
         self.length = length
         super(BinaryProperty, self).__init__()
 
-    if six.PY2:
-        def format(self, value):
+    def format(self, value):
+        if isinstance(value, bytes):
             return b64encode(value)
-
-    else:
-        # Python 3
-        def format(self, value):
-            if isinstance(value, bytes):
-                return b64encode(value)
-            else:
-                return b64encode(value.encode())
-
+        else:
+            return b64encode(value.encode())
 
     def parse(self, value):
         val = b64decode(value)
@@ -89,24 +77,14 @@ class StringProperty(MessageProperty):
     def escape_xml_string(string):
         return escape(string, quote=False)
 
-    if six.PY2:
-        def format(self, value):
-            if isinstance(value, str) or isinstance(value, unicode):
-                return self.escape_xml_string(value)
+    def format(self, value):
+        if isinstance(value, str):
+            return self.escape_xml_string(value)
 
-            return self.escape_xml_string(str(value))
+        if isinstance(value, bytes):
+            return self.escape_xml_string(value.decode())
 
-    else:
-        # Python 3
-        def format(self, value):
-            if isinstance(value, str):
-                return self.escape_xml_string(value)
-
-            if isinstance(value, bytes):
-                return self.escape_xml_string(value.decode())
-
-            return self.escape_xml_string(str(value))
-
+        return self.escape_xml_string(str(value))
 
     def parse(self, value):
         return value

--- a/irods/message/quasixml.py
+++ b/irods/message/quasixml.py
@@ -49,7 +49,7 @@ class Element():
         return '{}({})'.format(self.name, repr(self.body))
 
 
-class Token(object):
+class Token:
     """A utility class for parsing XML."""
     def __init__(self, s):
         """Create a `Token' object from `s', the text comprising the parsed token."""

--- a/irods/meta.py
+++ b/irods/meta.py
@@ -1,6 +1,4 @@
-import six
-
-class iRODSMeta(object):
+class iRODSMeta:
 
     def __init__(self, name, value, units=None, avu_id=None, create_time=None, modify_time=None):
         self.avu_id = avu_id
@@ -74,7 +72,7 @@ class AVUOperation(dict):
 
 import copy
 
-class iRODSMetaCollection(object):
+class iRODSMetaCollection:
 
     def __call__(self, admin = False, timestamps = False, **opts):
         x = copy.copy(self)
@@ -95,12 +93,8 @@ class iRODSMetaCollection(object):
         """
         Returns a list of iRODSMeta associated with a given key
         """
-        if six.PY2:
-            if isinstance(key, unicode):
-                key = key.encode('utf8')
-        else:
-            if isinstance(key, bytes):
-                key = key.decode('utf8')
+        if isinstance(key, bytes):
+            key = key.decode('utf8')
         if not isinstance(key, str):
             raise TypeError
         return [m for m in self._meta if m.name == key]

--- a/irods/models.py
+++ b/irods/models.py
@@ -1,13 +1,10 @@
-from __future__ import absolute_import
 from irods.column import Column, Integer, String, DateTime, Keyword
-import six
-
 
 class ModelBase(type):
     columns = {}
 
     def __new__(cls, name, bases, attr):
-        columns = [y for (x, y) in six.iteritems(attr) if isinstance(y, Column)]
+        columns = [y for (x, y) in attr.items() if isinstance(y, Column)]
         for col in columns:
             ModelBase.columns[col.icat_id] = col
         attr['_columns'] = columns
@@ -15,7 +12,7 @@ class ModelBase(type):
         return type.__new__(cls, name, bases, attr)
 
 
-class Model(six.with_metaclass(ModelBase, object)):
+class Model(metaclass = ModelBase):
     pass
 
 

--- a/irods/password_obfuscation.py
+++ b/irods/password_obfuscation.py
@@ -1,11 +1,9 @@
-from __future__ import absolute_import
 import hashlib
 import sys
 import os
 import time
 import random
 import string
-import six
 from irods import MAX_PASSWORD_LENGTH
 
 seq_list = [
@@ -229,7 +227,7 @@ def unscramble(s, key=default_password_key, scramble_prefix=default_scramble_pre
     for c in to_unscramble:
         if c in wheel:
             #the index of the target character in wheel
-            wheel_index = (wheel.index(c) - six.indexbytes(encoder_ring, encoder_ring_index % 61) - chain) % len(wheel)
+            wheel_index = (wheel.index(c) - encoder_ring[encoder_ring_index % 61] - chain) % len(wheel)
             unscrambled_string += wheel[wheel_index]
             if block_chaining:
                 chain = ord(c) & 0xff
@@ -257,7 +255,7 @@ def scramble(s, key=default_password_key, scramble_prefix=default_scramble_prefi
     for c in to_scramble:
         if c in wheel:
             #the index of the target character in wheel
-            wheel_index = (wheel.index(c) + six.indexbytes(encoder_ring, encoder_ring_index % 61) + chain) % len(wheel)
+            wheel_index = (wheel.index(c) + encoder_ring[encoder_ring_index % 61] + chain) % len(wheel)
             scrambled_string += wheel[wheel_index]
             if block_chaining:
                 chain = ord(scrambled_string[-1]) & 0xff

--- a/irods/pool.py
+++ b/irods/pool.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import datetime
 import logging
 import threading
@@ -29,7 +28,7 @@ def _adjust_timeout_to_pool_default(conn):
         return
     conn.socket.settimeout(desired_value)
 
-class Pool(object):
+class Pool:
 
     def __init__(self, account, application_name='', connection_refresh_time=-1, session = None):
         '''
@@ -74,7 +73,8 @@ class Pool(object):
                 # created more than 'connection_refresh_time' seconds ago,
                 # release the connection (as its stale) and create a new one
                 if self.refresh_connection and (curr_time - conn.create_time).total_seconds() > self.connection_refresh_time:
-                    logger.debug('Connection with id {} was created more than {} seconds ago. Releasing the connection and creating a new one.'.format(id(conn), self.connection_refresh_time))
+                    logger.debug(f"Connection with id {id(conn)} was created more than {self.connection_refresh_time} seconds ago. "
+                                 "Releasing the connection and creating a new one.")
                     # Since calling disconnect() repeatedly is safe, we call disconnect()
                     # here explicitly, instead of relying on the garbage collector to clean
                     # up the object and call disconnect(). This makes the behavior of the
@@ -82,11 +82,11 @@ class Pool(object):
                     conn.disconnect()
                     conn = Connection(self, self.account)
                     new_conn = True
-                    logger.debug("Created new connection with id: {}".format(id(conn)))
+                    logger.debug(f"Created new connection with id: {id(conn)}")
             except KeyError:
                 conn = Connection(self, self.account)
                 new_conn = True
-                logger.debug("No connection found in idle set. Created a new connection with id: {}".format(id(conn)))
+                logger.debug(f"No connection found in idle set. Created a new connection with id: {id(conn)}")
 
             self.active.add(conn)
 
@@ -95,15 +95,15 @@ class Pool(object):
                 Ticket._lowlevel_api_request(conn, "session", sess.ticket__)
                 sess.ticket_applied[conn] = True
 
-            logger.debug("Adding connection with id {} to active set".format(id(conn)))
+            logger.debug(f"Adding connection with id {id(conn)} to active set")
 
             # If the connection we're about to make active was cached, it already has a socket object internal to it,
             # so we potentially have to modify it to have the desired timeout.
             if not new_conn:
                 _adjust_timeout_to_pool_default(conn)
 
-        logger.debug('num active: {}'.format(len(self.active)))
-        logger.debug('num idle: {}'.format(len(self.idle)))
+        logger.debug(f'num active: {len(self.active)}')
+        logger.debug(f'num idle: {len(self.idle)}')
 
         return conn
 
@@ -111,16 +111,16 @@ class Pool(object):
         with self._lock:
             if conn in self.active:
                 self.active.remove(conn)
-                logger.debug("Removed connection with id: {} from active set".format(id(conn)))
+                logger.debug(f"Removed connection with id: {id(conn)} from active set")
                 if not destroy:
                     # If 'refresh_connection' flag is True, update connection's 'last_used_time'
                     if self.refresh_connection:
                         conn.last_used_time = datetime.datetime.now()
                     self.idle.add(conn)
-                    logger.debug("Added connection with id: {} to idle set".format(id(conn)))
+                    logger.debug(f"Added connection with id: {id(conn)} to idle set")
             elif conn in self.idle and destroy:
-                logger.debug("Destroyed connection with id: {}".format(id(conn)))
+                logger.debug(f"Destroying connection with id: {id(conn)}")
                 self.idle.remove(conn)
-        logger.debug('num active: {}'.format(len(self.active)))
-        logger.debug('num idle: {}'.format(len(self.idle)))
+        logger.debug(f'num active: {len(self.active)}')
+        logger.debug(f'num idle: {len(self.idle)}')
 

--- a/irods/query.py
+++ b/irods/query.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from collections import OrderedDict
 
 from irods import MAX_SQL_ROWS
@@ -11,7 +10,6 @@ from irods.message import (
 from irods.api_number import api_number
 from irods.exception import CAT_NO_ROWS_FOUND, MultipleResultsFound, NoResultFound
 from irods.results import ResultSet, SpecificQueryResultSet
-import six
 
 query_number = {'ORDER_BY': 0x400,
                 'ORDER_BY_DESC': 0x800,
@@ -27,7 +25,7 @@ query_number = {'ORDER_BY': 0x400,
                 'SELECT_COUNT': 6}
 
 
-class Query(object):
+class Query:
 
     def __init__(self, sess, *args, **kwargs):
         self.sess = sess
@@ -148,7 +146,7 @@ class Query(object):
 
     def _select_message(self):
         dct = OrderedDict([(column.icat_id, value)
-                           for (column, value) in six.iteritems(self.columns)])
+                           for (column, value) in self.columns.items()])
         return IntegerIntegerMap(dct)
 
     # todo store criterion for columns and criterion for keywords in seaparate
@@ -263,7 +261,7 @@ class Query(object):
 #         pass
 
 
-class SpecificQuery(object):
+class SpecificQuery:
 
     def __init__(self, sess, sql=None, alias=None, columns=None, args=None):
         if not sql and not alias:

--- a/irods/resource.py
+++ b/irods/resource.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
 from irods.models import Resource
 from irods.meta import iRODSMetaCollection
-import six
 
 
-class iRODSResource(object):
+class iRODSResource:
 
     def __init__(self, manager, result=None):
         self._hierarchy_string = ''
@@ -31,7 +29,7 @@ class iRODSResource(object):
         '''
         self.manager = manager
         if result:
-            for attr, value in six.iteritems(Resource.__dict__):
+            for attr, value in Resource.__dict__.items():
                 if not attr.startswith('_'):
                     try:
                         setattr(self, attr, result[value])

--- a/irods/results.py
+++ b/irods/results.py
@@ -1,18 +1,7 @@
-from __future__ import absolute_import
 from prettytable import PrettyTable
-
 from irods.models import ModelBase
-from six.moves import range
-from six import PY3
 
-
-try:
-    unicode         # Python 2
-except NameError:
-    unicode = str
-
-
-class ResultSet(object):
+class ResultSet:
 
     def __init__(self, raw):
         self.length = raw.rowCnt
@@ -48,10 +37,7 @@ class ResultSet(object):
         except (TypeError, ValueError):
             return (col, value)
 
-    _str_encode = staticmethod(lambda x:x.encode('utf-8') if type(x) is unicode else x)
-
-    _get_column_values = ( lambda self,index: [(col, col.value[index]) for col in self.cols]
-           ) if PY3 else ( lambda self,index: [(col, self._str_encode(col.value[index])) for col in self.cols] )
+    _get_column_values = (lambda self,index: [(col, col.value[index]) for col in self.cols]) 
 
     def _format_row(self, index):
         values = self._get_column_values(index)

--- a/irods/rule.py
+++ b/irods/rule.py
@@ -1,10 +1,8 @@
-from __future__ import absolute_import
 from irods.message import iRODSMessage, StringStringMap, RodsHostAddress, STR_PI, MsParam, MsParamArray, RuleExecutionRequest
 from irods.api_number import api_number
 import irods.exception as ex
 from io import open as io_open
 from irods.message import Message, StringProperty
-import six
 
 class RemoveRuleMessage(Message):
     #define RULE_EXEC_DEL_INP_PI "str ruleExecId[NAME_LEN];"
@@ -14,7 +12,7 @@ class RemoveRuleMessage(Message):
         super(RemoveRuleMessage,self).__init__()
         self.ruleExecId = str(id_)
 
-class Rule(object):
+class Rule:
     def __init__(self, session, rule_file=None, body='', params=None, output='', instance_name = None, irods_3_literal_style = False):
         """
         Initialize a rule object.
@@ -63,7 +61,7 @@ class Rule(object):
                 conn.send(request)
                 response = conn.recv()
                 if response.int_info != 0:
-                    raise RuntimeError("Error removing rule {id_}".format(**locals()))
+                    raise RuntimeError(f"Error removing rule {id_}")
 
     def load(self, rule_file, encoding = 'utf-8'):
         """Load rule code with rule-file (*.r) semantics.
@@ -87,7 +85,7 @@ class Rule(object):
         self.body = '@external\n'
 
 
-        with (io_open(rule_file, encoding = encoding) if isinstance(rule_file,six.string_types) else rule_file
+        with (io_open(rule_file, encoding = encoding) if isinstance(rule_file,str) else rule_file
         ) as f:
 
             # parse rule file line-by-line

--- a/irods/session.py
+++ b/irods/session.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 import ast
 import atexit
 import copy
@@ -59,7 +58,7 @@ logger = logging.getLogger(__name__)
 class NonAnonymousLoginWithoutPassword(RuntimeError): pass
 
 
-class iRODSSession(object):
+class iRODSSession:
 
     def library_features(self):
         irods_version_needed = (4,3,1)

--- a/irods/test/access_test.py
+++ b/irods/test/access_test.py
@@ -1,5 +1,4 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
 
 import os
 import sys

--- a/irods/test/admin_test.py
+++ b/irods/test/admin_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/client_hints_test.py
+++ b/irods/test/client_hints_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/collection_test.py
+++ b/irods/test/collection_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 from datetime import datetime
 import os
 import sys
@@ -12,7 +12,6 @@ from irods.exception import CollectionDoesNotExist
 from irods.models import Collection, DataObject
 import irods.test.helpers as helpers
 import irods.keywords as kw
-from six.moves import range
 from irods.test.helpers import my_function_name, unique_name
 from irods.collection import iRODSCollection
 
@@ -169,7 +168,7 @@ class TestCollection(unittest.TestCase):
 
 
     def test_repr_coll(self):
-        coll_name = self.test_coll.name.encode('utf-8')
+        coll_name = self.test_coll.name
         coll_id = self.test_coll.id
 
         self.assertEqual(

--- a/irods/test/connection_test.py
+++ b/irods/test/connection_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import tempfile

--- a/irods/test/exception_test.py
+++ b/irods/test/exception_test.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
+
 from datetime import datetime
 import errno
 import os

--- a/irods/test/extended_test.py
+++ b/irods/test/extended_test.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/file_test.py
+++ b/irods/test/file_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest
@@ -18,9 +18,9 @@ class TestFiles(unittest.TestCase):
         self.collection = self.sess.collections.create(self.coll_path)
 
         self.obj_name = 'test1'
-        self.content_str = u'blah'
-        self.write_str = u'0123456789'
-        self.write_str1 = u'INTERRUPT'
+        self.content_str = 'blah'
+        self.write_str = '0123456789'
+        self.write_str1 = 'INTERRUPT'
 
         self.test_obj_path = '{coll_path}/{obj_name}'.format(**vars(self))
 

--- a/irods/test/force_create.py
+++ b/irods/test/force_create.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/helpers.py
+++ b/irods/test/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-from __future__ import print_function
 import os
 import io
 import tempfile
@@ -22,9 +20,8 @@ from irods.session import iRODSSession
 from irods.message import (iRODSMessage, IRODS_VERSION)
 from irods.password_obfuscation import encode
 from irods import env_filename_from_keyword_args
-from six.moves import range
 
-class iRODSUserLogins(object):
+class iRODSUserLogins:
     """A class which creates users and set passwords from a given dict or list of tuples of
        (username,password).  
 
@@ -186,7 +183,7 @@ def home_collection(session):
 
 def make_object(session, path, content=None, **options):
     if content is None:
-        content = u'blah'
+        content = 'blah'
 
     content = iRODSMessage.encode_unicode(content)
 

--- a/irods/test/library_features_test.py
+++ b/irods/test/library_features_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/login_auth_test_must_run_manually.py
+++ b/irods/test/login_auth_test_must_run_manually.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
+
 import os
 import sys
 import tempfile
@@ -23,7 +22,6 @@ import contextlib
 import socket
 from re import compile as regex
 import gc
-import six
 from irods.test.setupssl import create_ssl_dir
 
 #
@@ -450,7 +448,6 @@ class TestMiscellaneous(unittest.TestCase):
         self.admin.users.remove('alice')
         self.admin.cleanup()
 
-    @unittest.skipUnless(six.PY3, "Skipping in Python2 because it doesn't reliably do cyclic GC.")
     def test_destruct_session_with_no_pool_315(self):
 
         destruct_flag = [False]

--- a/irods/test/message_test.py
+++ b/irods/test/message_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+
 import os
 import sys
 import time
@@ -13,8 +13,6 @@ from irods.models import (DataObject, Collection, Resource, CollectionMeta)
 import irods.test.helpers as helpers
 import irods.keywords as kw
 from irods.session import iRODSSession
-from six.moves import range
-from six import PY2, PY3
 from irods.message import Bad_AVU_Field
 from irods.column import Like, NotLike
 
@@ -47,7 +45,7 @@ class TestMeta(unittest.TestCase):
 
     def test_stringtypes_in_general_query__issue_442(self):
         metadata = []
-        value = u'a\u1000b'
+        value = 'a\u1000b'
         value_encoded = value.encode('utf8')
         contains_value = {type(value_encoded):b'%%'+value_encoded+b'%%',
                           type(value):'%%'+value+'%%'}
@@ -78,22 +76,9 @@ class TestMeta(unittest.TestCase):
         # Test that application of unicode and bytestring metadata were equivalent
         self.assertEqual(metadata[0], metadata[1])
 
-    @unittest.skipIf(PY3, 'Unicode strings are normal on Python3')
-    def test_unicode_AVUs_in_Python2__issue_442(self):
-        data_object = self.sess.data_objects.get(self.obj_path)
-        meta_set = iRODSMeta(u'\u1000', u'value', u'units')
-        meta_add = iRODSMeta(*tuple(meta_set))
-        meta_add.name += u"-add"
-        data_object.metadata.set(meta_set)
-        data_object.metadata.add(meta_add)
-        for index, meta in [(m.name, m) for m in (meta_add, meta_set)]:
-            fetched = data_object.metadata[index]
-            self.assertTrue(resolves_to_identical_bytestrings(fetched, meta), 'fetched unexpected meta for %r' % index)
-
-    @unittest.skipIf(PY2, 'Byte strings are normal on Python2')
     def test_bytestring_AVUs_in_Python3__issue_442(self):
         data_object = self.sess.data_objects.get(self.obj_path)
-        meta_set = iRODSMeta(u'\u1000'.encode('utf8'),b'value',b'units')
+        meta_set = iRODSMeta('\u1000'.encode('utf8'),b'value',b'units')
         meta_add = iRODSMeta(*tuple(meta_set))
         meta_add.name += b"-add"
         data_object.metadata.set(meta_set)
@@ -260,7 +245,7 @@ class TestMeta(unittest.TestCase):
                                iRODSMeta(self.attr1, self.value1, self.unit1))
 
         # Throw in some unicode for good measure
-        attribute, value = 'attr2', u'☭⛷★⚽'
+        attribute, value = 'attr2', '☭⛷★⚽'
         self.sess.metadata.add(DataObject, self.obj_path,
                                iRODSMeta(attribute, value))
 
@@ -281,8 +266,7 @@ class TestMeta(unittest.TestCase):
         assert meta[1].units == self.unit1
 
         assert meta[2].name == attribute
-        testValue = (value if PY3 else value.encode('utf8'))
-        assert meta[2].value == testValue
+        assert meta[2].value == value
 
 
     def test_add_obj_meta_empty(self):
@@ -560,7 +544,7 @@ class TestMeta(unittest.TestCase):
                 meta = d.metadata
                 avu = iRODSMeta('no_ts','val',units())
                 meta.set(avu)
-                self.assertEqual((None, None),		# Assert no timestamps are stored.
+                self.assertEqual((None, None),  # Assert no timestamps are stored.
                                  self.check_timestamps(meta, key = avu.name))
 
                 # -- Test metadata access with timestamps
@@ -572,11 +556,11 @@ class TestMeta(unittest.TestCase):
                 now = datetime.datetime.utcnow()
                 time.sleep(1.5)
                 avu_use_ts.units = units()
-                meta_ts.set(avu_use_ts)			# Set an AVU with modified units.
+                meta_ts.set(avu_use_ts)         # Set an AVU with modified units.
 
                 (create, modify) = self.check_timestamps(meta_ts, key = avu_use_ts.name)
 
-                self.assertLess(create, now)		#  Ensure timestamps are in proper order.
+                self.assertLess(create, now)    #  Ensure timestamps are in proper order.
                 self.assertLess(now, modify)
             finally:
                 if d: d.unlink(force = True)

--- a/irods/test/modules/test_auto_close_of_data_objects__issue_456.py
+++ b/irods/test/modules/test_auto_close_of_data_objects__issue_456.py
@@ -6,7 +6,6 @@
 #    irods.test.data_obj_test.TestDataObjOps.test_data_objects_auto_close_on_function_exit__issue_456
 #    irods.test.data_obj_test.TestDataObjOps.test_data_objects_auto_close_on_process_exit__issue_456
 
-from __future__ import print_function
 import contextlib
 try:
     import irods.client_configuration as config

--- a/irods/test/modules/test_saving_and_loading_of_settings__issue_471.py
+++ b/irods/test/modules/test_saving_and_loading_of_settings__issue_471.py
@@ -1,4 +1,3 @@
-from __future__ import print_function
 import sys
 import os
 import subprocess

--- a/irods/test/pool_test.py
+++ b/irods/test/pool_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import contextlib
 import datetime
 import gc

--- a/irods/test/query_test.py
+++ b/irods/test/query_test.py
@@ -1,9 +1,7 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
-from __future__ import absolute_import
+
 import os
-import six
 import sys
 import tempfile
 import unittest
@@ -25,7 +23,6 @@ from irods.rule import Rule
 from irods import MAX_SQL_ROWS
 from irods.test.helpers import irods_shared_reg_resc_vault
 import irods.test.helpers as helpers
-from six.moves import range as py3_range
 import irods.keywords as kw
 
 IRODS_STATEMENT_TABLE_SIZE = 50
@@ -601,32 +598,9 @@ class TestQuery(unittest.TestCase):
             return (dir_ , register_opts)
 
 
-    @unittest.skipIf(six.PY3, 'Test is for python2 only')
-    def test_query_for_data_object_with_utf8_name_python2(self):
-        reg_info = self.common_dir_or_vault_info()
-        if not reg_info:
-            self.skipTest('server is non-localhost and no common path exists for object registration')
-        (dir_,resc_option) = reg_info
-        filename_prefix = '_prefix_ǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸ'
-        self.assertEqual(self.FILENAME_PREFIX.encode('utf-8'), filename_prefix)
-        _,test_file = tempfile.mkstemp(dir=dir_,prefix=filename_prefix)
-        obj_path = os.path.join(self.coll.path, os.path.basename(test_file))
-        results = None
-        try:
-            self.sess.data_objects.register(test_file, obj_path, **resc_option)
-            results = self.sess.query(DataObject, Collection.name).filter(DataObject.path == test_file).first()
-            result_logical_path = os.path.join(results[Collection.name], results[DataObject.name])
-            result_physical_path = results[DataObject.path]
-            self.assertEqual(result_logical_path, obj_path)
-            self.assertEqual(result_physical_path, test_file)
-        finally:
-            if results: self.sess.data_objects.unregister(obj_path)
-            os.remove(test_file)
-
     # view/change this line in text editors under own risk:
-    FILENAME_PREFIX = u'_prefix_ǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸ' 
+    FILENAME_PREFIX = '_prefix_ǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸ'
 
-    @unittest.skipIf(six.PY2, 'Test is for python3 only')
     def test_query_for_data_object_with_utf8_name_python3(self):
         reg_info = self.common_dir_or_vault_info()
         if not reg_info:
@@ -637,9 +611,9 @@ class TestQuery(unittest.TestCase):
             encoded_file_path = file_path.encode('utf-8')
             return os.open(encoded_file_path,os.O_CREAT|os.O_RDWR,mode=open_mode), encoded_file_path
         fd = None
-        filename_prefix = u'_prefix_'\
-            u'\u01e0\u01e1\u01e2\u01e3\u01e4\u01e5\u01e6\u01e7\u01e8\u01e9\u01ea\u01eb\u01ec\u01ed\u01ee\u01ef'\
-            u'\u01f0\u01f1\u01f2\u01f3\u01f4\u01f5\u01f6\u01f7\u01f8'  # make more visible/changeable in VIM
+        filename_prefix = '_prefix_'\
+            '\u01e0\u01e1\u01e2\u01e3\u01e4\u01e5\u01e6\u01e7\u01e8\u01e9\u01ea\u01eb\u01ec\u01ed\u01ee\u01ef'\
+            '\u01f0\u01f1\u01f2\u01f3\u01f4\u01f5\u01f6\u01f7\u01f8'  # make more visible/changeable in VIM
         self.assertEqual(self.FILENAME_PREFIX, filename_prefix)
         (fd,encoded_test_file) = tempfile.mkstemp(dir = dir_.encode('utf-8'),prefix=filename_prefix.encode('utf-8')) \
             if sys.version_info >= (3,5) \
@@ -687,7 +661,7 @@ class TestQuery(unittest.TestCase):
                 for data_obj_path in map(lambda d:d[Collection.name]+"/"+d[DataObject.name],
                                          self.session.query(*q_params).filter(Collection.name == self.test_collection.path)):
                     data_obj = self.session.data_objects.get(data_obj_path)
-                    for key in (str(x) for x in py3_range(self.nAVUs)):
+                    for key in (str(x) for x in range(self.nAVUs)):
                         data_obj.metadata[key] = iRODSMeta(key, "1")
 
                 # - in subsequent test searches, match on each AVU of every data object in the collection:
@@ -789,8 +763,8 @@ class TestQuery(unittest.TestCase):
             Rule(self.sess).remove_by_id( results[0][RuleExec.id] )
 
     def test_utf8_equality_in_query__issue_442(self):
-        name = u'prefix-\u1000-suffix'
-        self.sess.data_objects.create(u'{}/{}'.format(self.coll_path, name))
+        name = 'prefix-\u1000-suffix'
+        self.sess.data_objects.create('{}/{}'.format(self.coll_path, name))
         query = self.sess.query(DataObject).filter( DataObject.name == name.encode('utf8'),
                                                     DataObject.collection_id == self.coll.id)
         self.assertEqual(1, len(list(query)))

--- a/irods/test/resource_test.py
+++ b/irods/test/resource_test.py
@@ -1,7 +1,6 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
-import six
 import sys
 import unittest
 
@@ -44,13 +43,13 @@ class TestResource(unittest.TestCase):
                             self.assertEqual(resc.parent_id, (None if n == 0 else parent_resc.id))
                             self.assertEqual(resc.parent_name, (None if n == 0 else parent_resc.name))
                             self.assertEqual(resc.hierarchy_string, hier_str)
-                            self.assertIs(type(resc.hierarchy_string), str)                   # type of hierarchy field is string.
+                            self.assertIs(type(resc.hierarchy_string), str)  # type of hierarchy field is string.
                             if resc.parent is None:
                                 self.assertIs(resc.parent_id, None)
                                 self.assertIs(resc.parent_name, None)
                             else:
-                                self.assertIn(type(resc.parent_id), six.integer_types) # type of a non-null id field is integer.
-                                self.assertIs(type(resc.parent_name), str)             # type of a non-null name field is string.
+                                self.assertIs(type(resc.parent_id), int)     # type of a non-null id field is integer.
+                                self.assertIs(type(resc.parent_name), str)   # type of a non-null name field is string.
                             parent_resc = resc
                 finally:
                     ses.resources.remove_child(root, pt + "_0")

--- a/irods/test/rule_test.py
+++ b/irods/test/rule_test.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+
 import os
 import sys
 import time
@@ -10,7 +10,6 @@ from irods.models import DataObject
 from irods.exception import (FAIL_ACTION_ENCOUNTERED_ERR, RULE_ENGINE_ERROR, UnknowniRODSError)
 import irods.test.helpers as helpers
 from irods.rule import Rule
-import six
 from io import open as io_open
 import io
 
@@ -297,14 +296,14 @@ class TestRule(unittest.TestCase):
         session = self.sess
 
         # test metadata
-        some_string = u'foo'
-        some_other_string = u'我喜欢麦当劳'
-        err_string = u'⛔'
+        some_string = 'foo'
+        some_other_string = '我喜欢麦当劳'
+        err_string = '⛔'
 
         # make rule file
         ts = time.time()
         rule_file_path = "/tmp/test_{ts}.r".format(**locals())
-        rule = textwrap.dedent(u'''\
+        rule = textwrap.dedent('''\
                                 test {{
                                     # write stuff
                                     writeLine("stdout", *some_string);
@@ -354,7 +353,7 @@ class TestRule(unittest.TestCase):
 
     def test_rulefile_in_file_like_object_1__336(self):
 
-        rule_file_contents = textwrap.dedent(u"""\
+        rule_file_contents = textwrap.dedent("""\
         hw {
                 helloWorld(*message);
                 writeLine("stdout", "Message is: [*message] ...");

--- a/irods/test/runner.py
+++ b/irods/test/runner.py
@@ -6,7 +6,7 @@ NOTE: "If a test package name (directory with __init__.py) matches the pattern
        exists then it will be called with loader, tests, pattern."
 """
 
-from __future__ import absolute_import
+
 import os
 import sys
 from unittest import TestLoader, TestSuite

--- a/irods/test/setupssl.py
+++ b/irods/test/setupssl.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 
-from __future__ import print_function
 import numbers
 import os
 import posix

--- a/irods/test/temp_password_test.py
+++ b/irods/test/temp_password_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/test/ticket_test.py
+++ b/irods/test/ticket_test.py
@@ -1,6 +1,5 @@
 #! /usr/bin/env python
-from __future__ import print_function
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest
@@ -43,7 +42,7 @@ class TestRodsUserTicketOps(unittest.TestCase):
 
     @staticmethod
     def irods_homedir(sess, path_only = False):
-        path = '/{0.zone}/home/{0.username}'.format(sess)
+        path = f"/{sess.zone}/home/{sess.username}"
         if path_only:
             return path
         return sess.collections.get(path)
@@ -313,7 +312,7 @@ class TestTicketOps(unittest.TestCase):
 
         # Create test collection
 
-        self.coll_path = '/{}/home/{}/ticket_test_dir'.format(admin.zone, admin.username)
+        self.coll_path = f'/{admin.zone}/home/{admin.username}/ticket_test_dir'
         self.coll = helpers.make_collection(admin, self.coll_path)
 
         # Create anonymous test user
@@ -327,7 +326,7 @@ class TestTicketOps(unittest.TestCase):
         # make new data object in the test collection with some initialized content
 
         self.INITIALIZED_DATA = b'1'*16
-        self.data_path = '{self.coll_path}/ticketed_data'.format(**locals())
+        self.data_path = f'{self.coll_path}/ticketed_data'
         helpers.make_object (admin, self.data_path, content = self.INITIALIZED_DATA)
 
         self.MODIFIED_DATA = b'2'*16

--- a/irods/test/unicode_test.py
+++ b/irods/test/unicode_test.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest
@@ -9,7 +9,6 @@ import xml.etree.ElementTree as ET
 from irods.message import (ET as ET_set, XML_Parser_Type, current_XML_parser, default_XML_parser)
 import logging
 import irods.test.helpers as helpers
-from six import PY3
 
 logger = logging.getLogger(__name__)
 
@@ -73,7 +72,7 @@ class TestUnicodeNames(unittest.TestCase):
         self.sess.cleanup()
 
     def test_object_name_containing_unicode__318(self):
-        dataname = u"réprouvé"
+        dataname = "réprouvé"
         homepath = helpers.home_collection( self.sess )
         try:
             ET_set( XML_Parser_Type.QUASI_XML, self.sess.server_version )
@@ -95,20 +94,17 @@ class TestUnicodeNames(unittest.TestCase):
         # queries return values of 'str' type in Python2.  When and if these quantities have a possibility
         # of representing unicode quantities, they can then go through a decode stage.
 
-        encode_unless_PY3 = (lambda x:x) if PY3 else (lambda x:x.encode('utf8'))
-        decode_unless_PY3 = (lambda x:x) if PY3 else (lambda x:x.decode('utf8'))
-
         for result in query:
             # check that we got back one of our original names
-            assert result[DataObject.name] in ( [encode_unless_PY3(n) for n in self.names] )
+            assert result[DataObject.name] in self.names
 
             # fyi
-            logger.info( u"{0}/{1}".format( decode_unless_PY3(result[Collection.name]),
-                                            decode_unless_PY3(result[DataObject.name]) )
+            logger.info( "{0}/{1}".format( result[Collection.name],
+                                           result[DataObject.name] )
                        )
 
             # remove from set
-            self.names.remove(decode_unless_PY3(result[DataObject.name]))
+            self.names.remove(result[DataObject.name])
 
         # make sure we got all of them
         self.assertEqual(0, len(self.names))

--- a/irods/test/user_group_test.py
+++ b/irods/test/user_group_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import datetime
 import os
 import sys
@@ -15,7 +15,6 @@ from irods.session import iRODSSession
 import irods.exception as ex
 import irods.test.helpers as helpers
 from irods.user import iRODSUser, Bad_password_change_parameter
-from six.moves import range
 
 def user_quotas_implemented():
     return getattr(iRODSUser, "set_quota", None) is not None

--- a/irods/test/zone_test.py
+++ b/irods/test/zone_test.py
@@ -1,5 +1,5 @@
 #! /usr/bin/env python
-from __future__ import absolute_import
+
 import os
 import sys
 import unittest

--- a/irods/ticket.py
+++ b/irods/ticket.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from irods.api_number import api_number
 from irods.message import iRODSMessage, TicketAdminRequest
 from irods.models import TicketQuery
@@ -30,7 +28,7 @@ def get_epoch_seconds (utc_timestamp):
         raise # final try at conversion, so a failure is an error
 
 
-class Ticket(object):
+class Ticket:
     def __init__(self, session,  ticket = '', result = None, allow_punctuation = False):
         self._session = session
         try:

--- a/irods/user.py
+++ b/irods/user.py
@@ -1,4 +1,3 @@
-from __future__ import absolute_import
 from irods.models import User, Group, UserAuth
 from irods.meta import iRODSMetaCollection
 from irods.exception import NoResultFound
@@ -7,7 +6,7 @@ _Not_Defined = ()
 
 class Bad_password_change_parameter(Exception): pass
 
-class iRODSUser(object):
+class iRODSUser:
 
     def remove_quota(self, resource = 'total'):
         self.manager.remove_quota(self.name, resource = resource)
@@ -62,7 +61,7 @@ class iRODSUser(object):
         self.manager.modify(self.name, *args, **kwargs)
 
     def __repr__(self):
-        return "<iRODSUser {id} {name} {type} {zone}>".format(**vars(self))
+        return f"<iRODSUser {self.id} {self.name} {self.type} {self.zone}>"
 
     def remove(self):
         self.manager.remove(self.name, self.zone, _object = self)
@@ -71,7 +70,7 @@ class iRODSUser(object):
         return self.manager.temp_password_for_user(self.name)
 
 
-class iRODSGroup(object):
+class iRODSGroup:
 
     type = "rodsgroup"
 
@@ -89,7 +88,7 @@ class iRODSGroup(object):
         self._meta = None
 
     def __repr__(self):
-        return "<iRODSGroup {id} {name}>".format(**vars(self))
+        return f"<iRODSGroup {self.id} {self.name}>"
 
     def remove(self):
         self.manager.remove(self.name, _object = self)

--- a/irods/zone.py
+++ b/irods/zone.py
@@ -1,8 +1,7 @@
-from __future__ import absolute_import
 from irods.models import Zone
 
 
-class iRODSZone(object):
+class iRODSZone:
 
     def __init__(self, manager, result=None):
         """Construct an iRODSZone object."""

--- a/setup.py
+++ b/setup.py
@@ -28,9 +28,6 @@ setup(name='python-irodsclient',
       classifiers=[
                    'License :: OSI Approved :: BSD License',
                    'Development Status :: 5 - Production/Stable',
-                   'Programming Language :: Python :: 2.7',
-                   'Programming Language :: Python :: 3.4',
-                   'Programming Language :: Python :: 3.5',
                    'Programming Language :: Python :: 3.6',
                    'Programming Language :: Python :: 3.7',
                    'Programming Language :: Python :: 3.8',
@@ -38,19 +35,16 @@ setup(name='python-irodsclient',
                    'Programming Language :: Python :: 3.10',
                    'Programming Language :: Python :: 3.11',
                    'Programming Language :: Python :: 3.12',
+                   'Programming Language :: Python :: 3.13',
                    'Operating System :: POSIX :: Linux',
                    ],
       packages=find_packages(),
       include_package_data=True,
       install_requires=[
-                        'six>=1.10.0',
                         'PrettyTable>=0.7.2',
                         'defusedxml',
-                        # - the new syntax:
-                        #'futures; python_version == "2.7"'
                         ],
-      # - the old syntax:
-      extras_require={ ':python_version == "2.7"': ['futures'],
+      extras_require={
                        'tests': ['unittest-xml-reporting']  # for xmlrunner
                      }
       )


### PR DESCRIPTION
With this change, we remove all code meant explicitly to deal with the possibility of the PRC's running under Python 2.  Especially the awkward (and sometimes voluminous) parts that interfere with a ready understanding of the code base as a whole.