### PR TITLE
650.m

### DIFF
--- a/irods/client_configuration/__init__.py
+++ b/irods/client_configuration/__init__.py
@@ -88,11 +88,12 @@ data_objects = DataObjects()
 class LegacyAuth(iRODSConfiguration):
     __slots__ = ('pam',)
     class Pam(iRODSConfiguration):
-        __slots__ = ('time_to_live_in_hours', 'password_for_auto_renew', 'store_password_to_environment')
+        __slots__ = ('time_to_live_in_hours', 'password_for_auto_renew', 'store_password_to_environment','force_use_of_dedicated_pam_api')
         def __init__(self):
             self.time_to_live_in_hours = 0 # -> We default to the server's TTL preference.
             self.password_for_auto_renew = ''
             self.store_password_to_environment = False
+            self.force_use_of_dedicated_pam_api = False
     def __init__(self):
         self.pam = self.Pam()
 

--- a/irods/connection.py
+++ b/irods/connection.py
@@ -11,7 +11,6 @@ from irods import MAX_NAME_LEN
 from ast import literal_eval as safe_eval
 import re
 
-PAM_PW_ESC_PATTERN = re.compile(r'([@=&;])')
 
 
 from irods.message import (
@@ -460,8 +459,7 @@ class Connection:
         import irods.client_configuration as cfg
         inline_password = (self.account.authentication_scheme == self.account._original_authentication_scheme)
         time_to_live_in_hours = cfg.legacy_auth.pam.time_to_live_in_hours
-        # For certain characters in the pam password, if they need escaping with '\' then do so.
-        new_pam_password = PAM_PW_ESC_PATTERN.sub(lambda m: '\\'+m.group(1), self.account.password)
+        new_pam_password = self.account.password
         if not inline_password and cfg.legacy_auth.pam.password_for_auto_renew is not None:
             # Login using PAM password from .irodsA
             try:
@@ -476,9 +474,13 @@ class Connection:
                 # Login succeeded, so we're within the time-to-live and can return without error.
                 return
 
+        # Some characters need to be escaped for the key-value format and parser.
+        KVP_ESCAPED_CHARS = r'\;='
+        kvp_escape = lambda s:''.join((fr'\{c}' if c in KVP_ESCAPED_CHARS else c) for c in s)
+
         # Generate a new PAM password.
         ctx_user = '%s=%s' % (AUTH_USER_KEY, self.account.client_user)
-        ctx_pwd = '%s=%s' % (AUTH_PWD_KEY, new_pam_password)
+        ctx_pwd = '%s=%s' % (AUTH_PWD_KEY, kvp_escape(new_pam_password))
         ctx_ttl = '%s=%s' % (AUTH_TTL_KEY, str(time_to_live_in_hours))
 
         ctx = ";".join([ctx_user, ctx_pwd, ctx_ttl])
@@ -487,16 +489,16 @@ class Connection:
             if getattr(self,'DISALLOWING_PAM_PLAINTEXT',True):
                 raise PlainTextPAMPasswordError
 
-        # In general authentication API, a ';' and '=' in the password would be misinterpreted due to those
-        # characters' special meaning in the context string parameter.
-        use_dedicated_pam_api = len(ctx) >= MAX_NAME_LEN or \
-                                {';','='}.intersection(set(new_pam_password))
+        use_dedicated_pam_api = (len(ctx) >= MAX_NAME_LEN) or \
+                                cfg.legacy_auth.pam.force_use_of_dedicated_pam_api
 
         if use_dedicated_pam_api:
+            method = "PamAuthRequest"
             message_body = PamAuthRequest( pamUser = self.account.client_user,
                                            pamPassword = new_pam_password,
                                            timeToLive = time_to_live_in_hours)
         else:
+            method = "PluginAuthMessage"
             message_body = PluginAuthMessage( auth_scheme_ = PAM_AUTH_SCHEME,  context_ = ctx)
 
         auth_req = iRODSMessage(
@@ -534,7 +536,7 @@ class Connection:
                 f.write(obf.encode(auth_out.result_))
                 logger.debug('new PAM pw write succeeded')
 
-        logger.info("PAM authorization validated")
+        logger.info(f"PAM authorization validated (via {method})")
 
     def read_file(self, desc, size=-1, buffer=None):
         if size < 0:

--- a/irods/test/scripts/test002_write_native_credentials_to_secrets_file.bats
+++ b/irods/test/scripts/test002_write_native_credentials_to_secrets_file.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 #
-# Test creation of .irodsA for iRODS native authentication using the free function,
-#    irods.client_init.write_pam_credentials_to_secrets_file
+# Test creation of .irodsA for iRODS pam_password authentication using the free function,
+#    irods.client_init.write_native_credentials_to_secrets_file
 
 . "$BATS_TEST_DIRNAME"/test_support_functions
 PYTHON=python3
@@ -10,26 +10,18 @@ PYTHON=python3
 # Run as ubuntu user with sudo; python_irodsclient must be installed (in either ~/.local or a virtualenv)
 #
 
-ALICES_OLD_PAM_PASSWD="test123"
-ALICES_NEW_PAM_PASSWD="new_pass"
+@test create_irods_secrets_file {
 
-setup()
-{
-    setup_pam_login_for_alice "$ALICES_OLD_PAM_PASSWD"
-}
-
-teardown()
-{
-    finalize_pam_login_for_alice
-    test_specific_cleanup
-}
-
-@test create_secrets_file {
-
-    # Old .irodsA is already created, so we delete it and alter the pam password.
-    sudo chpasswd <<<"alice:$ALICES_NEW_PAM_PASSWD"
-    rm -f ~/.irods/.irodsA
-    $PYTHON -c "import irods.client_init; irods.client_init.write_pam_credentials_to_secrets_file('$ALICES_NEW_PAM_PASSWD')"
+    rm -fr ~/.irods
+    mkdir ~/.irods
+    cat > ~/.irods/irods_environment.json <<-EOF
+	{ "irods_host":"$(hostname)",
+      "irods_port":1247,
+      "irods_user_name":"rods",
+      "irods_zone_name":"tempZone"
+    }
+	EOF
+    $PYTHON -c "import irods.client_init; irods.client_init.write_native_credentials_to_secrets_file('rods')"
 
     # Define the core Python to be run, basically a minimal code block ensuring that we can authenticate to iRODS
     # without an exception being raised.
@@ -42,6 +34,5 @@ print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
 "
     OUTPUT=$($PYTHON -c "$SCRIPT")
     # Assert passing value
-    [ $OUTPUT = "env_auth_scheme=pam_password" ]
-
+    [[ $OUTPUT = "env_auth_scheme=native" ]]
 }

--- a/irods/test/scripts/test003_write_pam_credentials_to_secrets_file.bats
+++ b/irods/test/scripts/test003_write_pam_credentials_to_secrets_file.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 #
-# Test creation of .irodsA for iRODS pam_password authentication using the free function,
-#    irods.client_init.write_native_credentials_to_secrets_file
+# Test creation of .irodsA for iRODS native authentication using the free function,
+#    irods.client_init.write_pam_credentials_to_secrets_file
 
 . "$BATS_TEST_DIRNAME"/test_support_functions
 PYTHON=python3
@@ -10,18 +10,26 @@ PYTHON=python3
 # Run as ubuntu user with sudo; python_irodsclient must be installed (in either ~/.local or a virtualenv)
 #
 
-@test create_irods_secrets_file {
+ALICES_OLD_PAM_PASSWD="test123"
+ALICES_NEW_PAM_PASSWD="new_pass"
 
-    rm -fr ~/.irods
-    mkdir ~/.irods
-    cat > ~/.irods/irods_environment.json <<-EOF
-	{ "irods_host":"$(hostname)",
-      "irods_port":1247,
-      "irods_user_name":"rods",
-      "irods_zone_name":"tempZone"
-    }
-	EOF
-    $PYTHON -c "import irods.client_init; irods.client_init.write_native_credentials_to_secrets_file('rods')"
+setup()
+{
+    setup_pam_login_for_alice "$ALICES_OLD_PAM_PASSWD"
+}
+
+teardown()
+{
+    finalize_pam_login_for_alice
+    test_specific_cleanup
+}
+
+@test create_secrets_file {
+
+    # Old .irodsA is already created, so we delete it and alter the pam password.
+    sudo chpasswd <<<"alice:$ALICES_NEW_PAM_PASSWD"
+    rm -f ~/.irods/.irodsA
+    $PYTHON -c "import irods.client_init; irods.client_init.write_pam_credentials_to_secrets_file('$ALICES_NEW_PAM_PASSWD')"
 
     # Define the core Python to be run, basically a minimal code block ensuring that we can authenticate to iRODS
     # without an exception being raised.
@@ -34,5 +42,6 @@ print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
 "
     OUTPUT=$($PYTHON -c "$SCRIPT")
     # Assert passing value
-    [ $OUTPUT = "env_auth_scheme=native" ]
+    [[ $OUTPUT = "env_auth_scheme=pam"* ]]
+
 }

--- a/irods/test/scripts/test005_write_pam_credentials_to_secrets_file.bats
+++ b/irods/test/scripts/test005_write_pam_credentials_to_secrets_file.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+#
+# Test creation of .irodsA for iRODS native authentication using the free function,
+#    irods.client_init.write_pam_credentials_to_secrets_file
+
+. "$BATS_TEST_DIRNAME"/test_support_functions
+PYTHON=python3
+
+# Setup/prerequisites are same as for login_auth_test.
+# Run as ubuntu user with sudo; python_irodsclient must be installed (in either ~/.local or a virtualenv)
+#
+
+ALICES_OLD_PAM_PASSWD="test123"
+ALICES_NEW_PAM_PASSWD="new_&@;=_pass"
+
+setup()
+{
+    setup_pam_login_for_alice "$ALICES_OLD_PAM_PASSWD"
+}
+
+teardown()
+{
+    finalize_pam_login_for_alice
+    test_specific_cleanup
+}
+
+@test create_secrets_file {
+
+    # Old .irodsA is already created, so we delete it and alter the pam password.
+    sudo chpasswd <<<"alice:$ALICES_NEW_PAM_PASSWD"
+    local logfile i
+    for force_long_token_compatible_api in False True; do
+        logfile=/tmp/prc_logs.$((++i))
+        sudo su - irods -c 'iadmin rpp alice'
+        rm -f ~/.irods/.irodsA
+        $PYTHON -c "import irods.client_init
+import logging
+logger = logging.getLogger('irods.connection')
+logger.setLevel(logging.INFO)
+logger.addHandler(logging.FileHandler('$logfile'))
+irods.client_configuration.legacy_auth.pam.force_use_of_dedicated_pam_api = $force_long_token_compatible_api
+irods.client_init.write_pam_credentials_to_secrets_file('$ALICES_NEW_PAM_PASSWD')"
+
+        # Make sure the iinit-like routines created the catalog entry for the PAM password using the algorithm we expected it to call.
+        log_content=$(cat $logfile)
+        declare -A method=([True]=PamAuthRequest
+                           [False]=PluginAuthMessage)
+         [[ $log_content =~ "PAM authorization validated (via ${method[$force_long_token_compatible_api]})" ]]
+
+        # Define the core Python to be run, basically a minimal code block ensuring that we can authenticate to iRODS
+        # without an exception being raised.
+
+        local SCRIPT="
+import irods
+import irods.test.helpers as h
+ses = h.make_session()
+ses.collections.get(h.home_collection(ses))
+print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
+"
+        OUTPUT=$($PYTHON -c "$SCRIPT")
+        # Assert passing value
+        [[ $OUTPUT = "env_auth_scheme=pam"* ]]
+    done
+}


### PR DESCRIPTION
Fix character escaping.

For servers in the 4.2 and 4.3 series, @ and & no longer need escaping.  We shall still escape `=` and `;` are still escaped due to their use as part of kvp (key-value pair) strings in the iRODS protocol.