### PR TITLE
[#641] avoid unnecessary SyntaxError message

### DIFF
--- a/irods/session.py
+++ b/irods/session.py
@@ -320,11 +320,10 @@ class iRODSSession:
 
     @property
     def server_version(self):
-        try:
-            reported_vsn = os.environ.get("PYTHON_IRODSCLIENT_REPORTED_SERVER_VERSION","")
-            return tuple(ast.literal_eval(reported_vsn))
-        except SyntaxError:  # environment variable was malformed, empty, or unset
-            return self.__server_version()
+        reported_vsn = os.environ.get("PYTHON_IRODSCLIENT_REPORTED_SERVER_VERSION","")
+        if reported_vsn:
+            return tuple(ast.literal_eval(reported_vsn)) 
+        return self.__server_version()
 
     def __server_version(self):
         try:


### PR DESCRIPTION
Other parts of the error dump (detailng three levels of stacked exceptions) already give enough complexity for the troubleshooter to deal with, so this change helps us by avoiding a fourth: a SyntaxError easily avoided by jumping around the situation we found ourselves in with #641, and that was doing an eval on a string that could be empty.  Bad progammer!