### PR TITLE
[#635]  client_init free functions can now suppress overwriting old .irodsA

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,9 @@ Note, in the `pam_password` case, this involves sending the cleartext password
 to the server (SSL should thus be enabled!) and then writing the scrambled token that
 returns from the transaction.
 
-If an .irodsA file exists already, it will be overwritten.
+If an .irodsA file exists already, it will be overwritten by default; however, if these functions'
+overwrite parameter is set to `False`, an exception of type `irods.client_init.irodsA_already_exists`
+will be raised to indicate the older .irodsA file is present.
 
 Examples:
 For the `native` authentication scheme, we can use the currently set iRODS password to create .irodsA file from Python thus:

--- a/irods/test/scripts/test002_write_native_credentials_to_secrets_file.bats
+++ b/irods/test/scripts/test002_write_native_credentials_to_secrets_file.bats
@@ -1,7 +1,7 @@
 #!/usr/bin/env bats
 #
 # Test creation of .irodsA for iRODS native authentication using the free function,
-#    irods.client_init.write_pam_credentials_to_secrets_file
+#    irods.client_init.write_native_credentials_to_secrets_file
 
 . "$BATS_TEST_DIRNAME"/test_support_functions
 PYTHON=python3
@@ -10,26 +10,18 @@ PYTHON=python3
 # Run as ubuntu user with sudo; python_irodsclient must be installed (in either ~/.local or a virtualenv)
 #
 
-ALICES_OLD_PAM_PASSWD="test123"
-ALICES_NEW_PAM_PASSWD="new_pass"
+@test create_irods_secrets_file {
 
-setup()
-{
-    setup_pam_login_for_alice "$ALICES_OLD_PAM_PASSWD"
-}
-
-teardown()
-{
-    finalize_pam_login_for_alice
-    test_specific_cleanup
-}
-
-@test create_secrets_file {
-
-    # Old .irodsA is already created, so we delete it and alter the pam password.
-    sudo chpasswd <<<"alice:$ALICES_NEW_PAM_PASSWD"
-    rm -f ~/.irods/.irodsA
-    $PYTHON -c "import irods.client_init; irods.client_init.write_pam_credentials_to_secrets_file('$ALICES_NEW_PAM_PASSWD')"
+    rm -fr ~/.irods
+    mkdir ~/.irods
+    cat > ~/.irods/irods_environment.json <<-EOF
+	{ "irods_host":"$(hostname)",
+      "irods_port":1247,
+      "irods_user_name":"rods",
+      "irods_zone_name":"tempZone"
+    }
+	EOF
+    $PYTHON -c "import irods.client_init; irods.client_init.write_native_credentials_to_secrets_file('rods')"
 
     # Define the core Python to be run, basically a minimal code block ensuring that we can authenticate to iRODS
     # without an exception being raised.
@@ -42,6 +34,5 @@ print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
 "
     OUTPUT=$($PYTHON -c "$SCRIPT")
     # Assert passing value
-    [ $OUTPUT = "env_auth_scheme=pam_password" ]
-
+    [ $OUTPUT = "env_auth_scheme=native" ]
 }

--- a/irods/test/scripts/test003_write_pam_credentials_to_secrets_file.bats
+++ b/irods/test/scripts/test003_write_pam_credentials_to_secrets_file.bats
@@ -42,6 +42,6 @@ print ('env_auth_scheme=%s' % ses.pool.account._original_authentication_scheme)
 "
     OUTPUT=$($PYTHON -c "$SCRIPT")
     # Assert passing value
-    [ $OUTPUT = "env_auth_scheme=pam_password" ]
+    [[ $OUTPUT = "env_auth_scheme=pam"* ]]
 
 }


### PR DESCRIPTION

A new parameter named "overwrite", determines whether an old file will be overwritten, and defaults to True.

Also: we add a helper function `_open_for_protected_content`, a context manager which encapsulates the opening for write, writing, and closing of a file with protected content (ie only readable by the owner, using a umask of 077 octal by default).