### PR TITLE
[670] replace use of deprecated utcfromtimestamp

### DIFF
--- a/irods/column.py
+++ b/irods/column.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from calendar import timegm
 
 
@@ -146,7 +146,7 @@ class DateTime(ColumnType):
 
     @staticmethod
     def to_python(string):
-        return datetime.utcfromtimestamp(int(string))
+        return datetime.fromtimestamp(int(string), timezone.utc)
 
     @staticmethod
     def to_irods(data):

--- a/irods/test/collection_test.py
+++ b/irods/test/collection_test.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from datetime import datetime
+from datetime import datetime, timezone
 import os
 import sys
 import socket
@@ -412,7 +412,7 @@ class TestCollection(unittest.TestCase):
 
         # Compare mtimes for correctness.
         collection = user_session.collections.get(home_collection_path)
-        self.assertEqual(datetime.utcfromtimestamp(new_mtime), collection.modify_time)
+        self.assertEqual(datetime.fromtimestamp(new_mtime, timezone.utc), collection.modify_time)
         self.assertGreater(old_mtime, collection.modify_time)
 
     def test_touch_operation_does_not_create_new_collections__525(self):
@@ -486,7 +486,7 @@ class TestCollection(unittest.TestCase):
 
             # Compare mtimes for correctness.
             collection = user_session.collections.get(path)
-            self.assertEqual(datetime.utcfromtimestamp(int(new_mtime)), collection.modify_time)
+            self.assertEqual(datetime.fromtimestamp(int(new_mtime), timezone.utc), collection.modify_time)
 
         finally:
             if collection:

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-from datetime import datetime
+from datetime import datetime, timezone
 import base64
 import concurrent.futures
 import contextlib
@@ -1600,7 +1600,7 @@ class TestDataObjOps(unittest.TestCase):
         qu = self.sess.query(DataObject.size, DataObject.modify_time).filter(DataObject.name == filename, DataObject.collection_id == collection_id)
         for res in qu:
             self.assertEqual(int(res[DataObject.size]), 1024)
-            self.assertEqual(res[DataObject.modify_time], datetime.utcfromtimestamp(4096))
+            self.assertEqual(res[DataObject.modify_time], datetime.fromtimestamp(4096, timezone.utc))
 
         # leave physical file on disk
         self.sess.data_objects.unregister(obj_path)
@@ -2156,7 +2156,7 @@ class TestDataObjOps(unittest.TestCase):
 
             # Compare mtimes for correctness.
             data_object = user_session.data_objects.get(data_object_path)
-            self.assertEqual(datetime.utcfromtimestamp(int(new_mtime)), data_object.replicas[0].modify_time)
+            self.assertEqual(datetime.fromtimestamp(int(new_mtime), timezone.utc), data_object.replicas[0].modify_time)
             self.assertGreater(old_mtime, data_object.replicas[0].modify_time)
 
         finally:

--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -557,7 +557,7 @@ class TestMeta(unittest.TestCase):
                 avu_use_ts = iRODSMeta('use_ts','val',units())
                 meta_ts.set(avu_use_ts)
                 time.sleep(1.5)
-                now = datetime.datetime.utcnow()
+                now = datetime.datetime.now(datetime.timezone.utc)
                 time.sleep(1.5)
                 avu_use_ts.units = units()
                 meta_ts.set(avu_use_ts)         # Set an AVU with modified units.

--- a/irods/test/query_test.py
+++ b/irods/test/query_test.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 import time
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from irods.models import (User, UserMeta,
                           Resource, ResourceMeta,
                           Collection, CollectionMeta,
@@ -466,7 +466,7 @@ class TestQuery(unittest.TestCase):
         session = self.sess
 
         start_date = datetime(2016, 1, 1, 0, 0)
-        end_date = datetime.utcnow()
+        end_date = datetime.now(timezone.utc)
 
         query = session.query(Resource.name, Collection.name, DataObject.name)\
             .filter(Between(DataObject.modify_time, (start_date, end_date)))
@@ -543,10 +543,10 @@ class TestQuery(unittest.TestCase):
             AVU_unique_incr = lambda obj,suffix='' : ( 'a_'+suffix,
                                                        'v_'+suffix,
                                                        str_number_incr(avu.units for avu in obj.metadata.items()) )
-            before = datetime.utcnow()
+            before = datetime.now(timezone.utc)
             time.sleep(1.5)
             for suffix,obj in objects.items(): obj.metadata.add( *AVU_unique_incr(obj,suffix) )
-            after = datetime.utcnow()
+            after = datetime.now(timezone.utc)
             for suffix, tblpair in tables.items():
                 self.sess.query( *tblpair ).filter(tblpair[1].modify_time <= after )\
                                            .filter(tblpair[1].modify_time > before )\


### PR DESCRIPTION
not tested, just find/replaced.

@d-w-moore please run this through testing