### PR TITLE
[664] bump version to v3.0.0

### DIFF
--- a/irods/version.py
+++ b/irods/version.py
@@ -1,6 +1,6 @@
 import os
 
-__version__ = "2.2.0"
+__version__ = "3.0.0"
 
 
 def version_as_string():


### PR DESCRIPTION
builds correctly, passes `twine check`.

this will be a Py3-only PyPI release.