### PR TITLE
Fix some SyntaxWarnings in the tests

### DIFF
--- a/irods/test/admin_test.py
+++ b/irods/test/admin_test.py
@@ -376,7 +376,7 @@ class TestAdmin(unittest.TestCase):
         self.sess.users.create(self.new_user_name, self.new_user_type)
 
         # make a really horrible password
-        new_password = """abc123!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~Z"""
+        new_password = r"""abc123!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~Z"""
         self.sess.users.modify(username, "password", new_password)
 
         # open a session as the new user
@@ -403,7 +403,7 @@ class TestAdmin(unittest.TestCase):
         self.sess.users.create(self.new_user_name, self.new_user_type)
 
         # modify user comment
-        new_comment = """comment-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
+        new_comment = r"""comment-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
         self.sess.users.modify(self.new_user_name, "comment", new_comment)
 
         # check comment was modified
@@ -422,7 +422,7 @@ class TestAdmin(unittest.TestCase):
         self.sess.users.create(self.new_user_name, self.new_user_type)
 
         # modify user info
-        new_info = """info-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
+        new_info = r"""info-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
         self.sess.users.modify(self.new_user_name, "info", new_info)
 
         # check info was modified

--- a/irods/test/data_obj_test.py
+++ b/irods/test/data_obj_test.py
@@ -34,7 +34,7 @@ except ImportError:
     progressbar = None
 
 ip_pattern = re.compile(r"(\d+)\.(\d+)\.(\d+)\.(\d+)$")
-localhost_with_optional_domain_pattern = re.compile("localhost(\.\S\S*)?$")
+localhost_with_optional_domain_pattern = re.compile(r"localhost(\.\S\S*)?$")
 
 
 def is_localhost_ip(s):
@@ -268,7 +268,7 @@ class TestDataObjOps(unittest.TestCase):
         required_num_replicas=1,
         seconds_to_wait_for_replicas=10,
     ):
-        """Helper function for testing irods/irods#5548 and irods/irods#5848.
+        r"""Helper function for testing irods/irods#5548 and irods/irods#5848.
 
         Writes the  string "books\n" to a replica, but not as a single write operation.
         It is done piecewise on two independent connections, essentially simulating parallel "put".
@@ -417,7 +417,7 @@ class TestDataObjOps(unittest.TestCase):
 
             PUT_LOG = io.StringIO()
             GET_LOG = io.StringIO()
-            NumThreadsRegex = re.compile("^num_threads\s*=\s*(\d+)", re.MULTILINE)
+            NumThreadsRegex = re.compile(r"^num_threads\s*=\s*(\d+)", re.MULTILINE)
 
             try:
                 logger = logging.getLogger("irods.parallel")
@@ -601,7 +601,7 @@ class TestDataObjOps(unittest.TestCase):
                 )
 
                 NO_CHECKSUM_MESSAGE_PATTERN = re.compile(
-                    "No\s+Checksum\s+Available.+\s+Replica\s\[(\d+)\]", re.IGNORECASE
+                    r"No\s+Checksum\s+Available.+\s+Replica\s\[(\d+)\]", re.IGNORECASE
                 )
 
                 Reported_repls_without_checksum = set(
@@ -1046,8 +1046,8 @@ class TestDataObjOps(unittest.TestCase):
                         nthr = 0
                         search_text = BUF.getvalue()
                         find_iterator = itertools.chain(
-                            re.finditer("redirect_to_host = (\S+)", search_text),
-                            re.finditer("target_host = (\S+)", search_text),
+                            re.finditer(r"redirect_to_host = (\S+)", search_text),
+                            re.finditer(r"target_host = (\S+)", search_text),
                         )
                         for match in find_iterator:
                             nthr += 1

--- a/irods/test/rule_test.py
+++ b/irods/test/rule_test.py
@@ -420,7 +420,7 @@ class TestRule(unittest.TestCase):
         )
         output = r.execute()
         lines = self.lines_from_stdout_buf(output)
-        self.assertRegexpMatches(lines[0], ".*\[Hello world!\]")
+        self.assertRegexpMatches(lines[0], r".*\[Hello world!\]")
 
     def test_rulefile_in_file_like_object_2__336(self):
 
@@ -442,8 +442,8 @@ class TestRule(unittest.TestCase):
         r = Rule(self.sess, rule_file=io.BytesIO(rule_file_contents.encode("utf-8")))
         output = r.execute()
         lines = self.lines_from_stdout_buf(output)
-        self.assertRegexpMatches(lines[0], "\[STRING\]\[\]")
-        self.assertRegexpMatches(lines[1], "\[STRING\]\[\]")
+        self.assertRegexpMatches(lines[0], r"\[STRING\]\[\]")
+        self.assertRegexpMatches(lines[1], r"\[STRING\]\[\]")
 
         r = Rule(
             self.sess,
@@ -452,8 +452,8 @@ class TestRule(unittest.TestCase):
         )
         output = r.execute()
         lines = self.lines_from_stdout_buf(output)
-        self.assertRegexpMatches(lines[0], "\[INTEGER\]\[5\]")
-        self.assertRegexpMatches(lines[1], "\[STRING\]\[A String\]")
+        self.assertRegexpMatches(lines[0], r"\[INTEGER\]\[5\]")
+        self.assertRegexpMatches(lines[1], r"\[STRING\]\[A String\]")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Change strings with backslashes that are not intended to be part of backslash escape sequences to raw strings. Most but not all such strings are regular expression patterns.

Fixes a number of instances of:

```
SyntaxWarning: invalid escape sequence
```

----

Before this PR:

```
$ find . -name '*.py[co]' -delete
$ python3.13 -m compileall irods | grep Syntax
irods/test/admin_test.py:379: SyntaxWarning: invalid escape sequence '\]'
  new_password = """abc123!"#$%&'()*+,-./:;<=>?@[\]^_`{|}~Z"""
irods/test/admin_test.py:406: SyntaxWarning: invalid escape sequence '\]'
  new_comment = """comment-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
irods/test/admin_test.py:425: SyntaxWarning: invalid escape sequence '\]'
  new_info = """info-abc123!"#$%&'()*+,-./:;<=>?@[\]^_{|}~Z"""  # omitting backtick due to #170
irods/test/data_obj_test.py:37: SyntaxWarning: invalid escape sequence '\.'
  localhost_with_optional_domain_pattern = re.compile("localhost(\.\S\S*)?$")
irods/test/data_obj_test.py:420: SyntaxWarning: invalid escape sequence '\s'
  NumThreadsRegex = re.compile("^num_threads\s*=\s*(\d+)", re.MULTILINE)
irods/test/data_obj_test.py:604: SyntaxWarning: invalid escape sequence '\s'
  "No\s+Checksum\s+Available.+\s+Replica\s\[(\d+)\]", re.IGNORECASE
irods/test/data_obj_test.py:1049: SyntaxWarning: invalid escape sequence '\S'
  re.finditer("redirect_to_host = (\S+)", search_text),
irods/test/data_obj_test.py:1050: SyntaxWarning: invalid escape sequence '\S'
  re.finditer("target_host = (\S+)", search_text),
irods/test/rule_test.py:423: SyntaxWarning: invalid escape sequence '\['
  self.assertRegexpMatches(lines[0], ".*\[Hello world!\]")
irods/test/rule_test.py:445: SyntaxWarning: invalid escape sequence '\['
  self.assertRegexpMatches(lines[0], "\[STRING\]\[\]")
irods/test/rule_test.py:446: SyntaxWarning: invalid escape sequence '\['
  self.assertRegexpMatches(lines[1], "\[STRING\]\[\]")
irods/test/rule_test.py:455: SyntaxWarning: invalid escape sequence '\['
  self.assertRegexpMatches(lines[0], "\[INTEGER\]\[5\]")
irods/test/rule_test.py:456: SyntaxWarning: invalid escape sequence '\['
  self.assertRegexpMatches(lines[1], "\[STRING\]\[A String\]")
```

After this PR:

```
$ find . -name '*.py[co]' -delete
$ python3.13 -m compileall irods | grep Syntax
[no output]
```