### PR TITLE
[_709] preserve options in chaining obj.metadata(opt1=val1)(opt2=val2)

### DIFF
--- a/irods/manager/metadata_manager.py
+++ b/irods/manager/metadata_manager.py
@@ -33,18 +33,37 @@ class MetadataManager(Manager):
         return getattr(self, "_use_ts", False)
 
     __kw = {}  # default (empty) keywords
+    _admin = False
+    _use_ts = False
 
     def _updated_keywords(self, opts):
         kw_ = self.__kw.copy()
         kw_.update(opts)
         return kw_
 
-    def __call__(self, admin=False, timestamps=False, **irods_kw_opt):
-        if admin:
-            irods_kw_opt.update([(kw.ADMIN_KW, "")])
+    __generate_new_options = staticmethod(lambda obj, from_kw: { 'admin':obj._admin,
+                                                                 'timestamps':obj._use_ts,
+                                                                 **from_kw })
+
+    def get_api_keywords(self): return self.__kw.copy()
+
+    def __call__(self, **kw_opt):
+        # Make a new shallow copy of the manager object, but update options from parameter list.
         new_self = copy.copy(self)
-        new_self._use_ts = timestamps
-        new_self.__kw = irods_kw_opt
+        new_options = new_self.__kw = self.__generate_new_options(new_self, kw_opt)
+
+        # Update the flags that do bookkeeping in the returned(new) manager object.
+        if (timestamps:=new_options.pop('timestamps',None)) is not None:
+            new_self._use_ts = timestamps
+        if (admin:=new_options.pop('admin',None)) is not None:
+            new_self._admin = admin
+
+        # Update the ADMIN_KW flag in the returned(new) object.
+        if new_self._admin:
+            new_options[kw.ADMIN_KW] = ""
+        else:
+            new_options.pop(kw.ADMIN_KW, None)
+
         return new_self
 
     @staticmethod

--- a/irods/meta.py
+++ b/irods/meta.py
@@ -89,9 +89,14 @@ import copy
 
 class iRODSMetaCollection:
 
-    def __call__(self, admin=False, timestamps=False, **opts):
+    def __call__(self, **opts):
+        """Optional parameters in **opts are:
+
+        admin (default: False): apply ADMIN_KW to future metadata operations.
+        timestamps (default: False): attach (ctime,mtime) timestamp attributes to AVUs received from iRODS.
+        """
         x = copy.copy(self)
-        x._manager = (x._manager)(admin, timestamps, **opts)
+        x._manager = (x._manager)(**opts)
         x._reset_metadata()
         return x
 

--- a/irods/test/meta_test.py
+++ b/irods/test/meta_test.py
@@ -796,6 +796,28 @@ class TestMeta(unittest.TestCase):
                 # in use, with the "odd" characters being present in the metadata value.
                 del obj.metadata[attr_str]
 
+    def test_cascading_changes_of_metadata_manager_options__issue_709(self):
+        d = None
+        try:
+            d = self.sess.data_objects.create(f'{self.coll.path}/issue_709_test_1')
+            m = d.metadata
+            self.assertEqual(m._manager._admin,False)
+
+            m2 = m(admin = True)
+            self.assertEqual(m2._manager._use_ts,False)
+            self.assertEqual(m2._manager._admin,True)
+
+            m3 = m2(timestamps = True)
+            self.assertEqual(m3._manager._use_ts, True)
+            self.assertEqual(m3._manager._admin, True)
+            self.assertEqual(m3._manager.get_api_keywords().get(kw.ADMIN_KW), "")
+
+            m4 = m3(admin = False)
+            self.assertEqual(m4._manager._use_ts, True)
+            self.assertEqual(m4._manager.get_api_keywords().get(kw.ADMIN_KW), None)
+        finally:
+            if d:
+                d.unlink(force=True)
 
 if __name__ == "__main__":
     # let the tests find the parent irods lib


### PR DESCRIPTION
In other words, setting opt2 = val2 does not reset opt1 back to its default value.