### PR TITLE
[#746] can now give (repl) row result sort function in DataObject constructor

### DIFF
--- a/irods/data_object.py
+++ b/irods/data_object.py
@@ -46,10 +46,13 @@ class iRODSReplica:
 
 class iRODSDataObject:
 
-    def __init__(self, manager, parent=None, results=None):
+    def __init__(self, manager, /, parent=None, results=None, *, results_sort_key = None):
         self.manager = manager
         if parent and results:
             self.collection = parent
+            if results_sort_key is None:
+                results_sort_key = lambda r: r[DataObject.replica_number]
+            results = sorted(results, key=results_sort_key)
             for attr, value in DataObject.__dict__.items():
                 if not attr.startswith("_"):
                     try:
@@ -58,7 +61,6 @@ class iRODSDataObject:
                         # backward compatibility with older schema versions
                         pass
             self.path = self.collection.path + "/" + self.name
-            replicas = sorted(results, key=lambda r: r[DataObject.replica_number])
             self.replicas = [
                 iRODSReplica(
                     r[DataObject.replica_number],
@@ -72,7 +74,7 @@ class iRODSDataObject:
                     create_time=r[DataObject.create_time],
                     modify_time=r[DataObject.modify_time],
                 )
-                for r in replicas
+                for r in results
             ]
         self._meta = None
 

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -273,6 +273,7 @@ class DataObjectManager(Manager):
         a path in the local filesystem to use as a destination file).
         """
         parent = self.sess.collections.get(irods_dirname(path))
+        _results_sort_key = options.pop('results_sort_key', None)
 
         # TODO: optimize
         if local_path:
@@ -300,7 +301,7 @@ class DataObjectManager(Manager):
         results = query.all()  # get up to max_rows replicas
         if len(results) <= 0:
             raise ex.DataObjectDoesNotExist()
-        return iRODSDataObject(self, parent, results)
+        return iRODSDataObject(self, parent, results, results_sort_key = _results_sort_key)
 
     def put(
         self,


### PR DESCRIPTION
This affects the overall {create,access,modify}_time, which is simplistically extracted from the first row in the query result-set.