### PR TITLE
[#750] import os module for StopTestsException

### DIFF
--- a/irods/helpers/__init__.py
+++ b/irods/helpers/__init__.py
@@ -1,4 +1,5 @@
 import contextlib
+import os
 import sys
 from irods import env_filename_from_keyword_args
 import irods.exception as ex


### PR DESCRIPTION
When `StopTestsException` was moved to `irods.helpers` from `irods.test.helpers`, the import os should have been added at the head of `irods/helpers/__init__.py`

This corrects the omission.