### PR TITLE
[#771] Use named loggers instead of directly calling logging

### DIFF
--- a/irods/auth/__init__.py
+++ b/irods/auth/__init__.py
@@ -17,6 +17,9 @@ AUTH_PLUGIN_PACKAGE = "irods.auth"
 _NoneType = type(None)
 
 
+_logger = logging.getLogger(__name__)
+
+
 class AuthStorage:
     """A class that facilitates flexible means of password storage.
 
@@ -166,7 +169,7 @@ class authentication_base:
         self.scheme = scheme
 
     def call(self, next_operation, request):
-        logging.debug("next operation = %r", next_operation)
+        _logger.debug("next operation = %r", next_operation)
         old_func = func = next_operation
         # One level of indirection should be sufficient to get a callable method.
         if not callable(func):
@@ -175,7 +178,7 @@ class authentication_base:
         if not callable(func):
             raise RuntimeError("client request contains no callable 'next_operation'")
         resp = func(request)
-        logging.debug("resp = %r", resp)
+        _logger.debug("resp = %r", resp)
         return resp
 
     def authenticate_client(
@@ -202,4 +205,4 @@ class authentication_base:
                 )
             to_send = resp
 
-        logging.debug("fully authenticated")
+        _logger.debug("fully authenticated")

--- a/irods/manager/data_object_manager.py
+++ b/irods/manager/data_object_manager.py
@@ -404,7 +404,7 @@ class DataObjectManager(Manager):
                 # We'll get a response in the client to help qualify or elaborate on the error thrown.
                 if msg_retn:
                     response = msg_retn[0]
-                logging.warning("Exception checksumming data object %r - %r", path, exc)
+                logger.warning("Exception checksumming data object %r - %r", path, exc)
             if "response" in locals():
                 try:
                     results = response.get_main_message(

--- a/irods/path/__init__.py
+++ b/irods/path/__init__.py
@@ -7,6 +7,9 @@ import logging
 import os
 
 
+_logger = logging.getLogger(__name__)
+
+
 class iRODSPath(str):
     """A subclass of the Python string that normalizes iRODS logical paths."""
 
@@ -49,7 +52,7 @@ class iRODSPath(str):
         """
         absolute_ = kw.pop("absolute", True)
         if kw:
-            logging.warning("These iRODSPath options have no effect: %r", kw.items())
+            _logger.warning("These iRODSPath options have no effect: %r", kw.items())
         normalized = _normalize_iRODS_logical_path(elem_list, absolute_)
         obj = str.__new__(cls, normalized)
         return obj


### PR DESCRIPTION
In most places, python-irodsclient uses named loggers (e.g., `logger = logging.getLogger(__name__); logger.debug(...)`). This is nice because it allows to separate logging done by the Python code using the irodsclient from the logging of irodsclient itself. There were however still a few cases where the root logger was used and this PR corrects that.