### PR TITLE
[#600] prevent case-sensitive testing with BETWEEN where infeasible

### DIFF
--- a/irods/test/query_test.py
+++ b/irods/test/query_test.py
@@ -213,30 +213,6 @@ class TestQuery(unittest.TestCase):
         )
         self.assertEqual(len(result12), 0)
 
-        # BETWEEN tests
-
-        # TODO(#600): Uncomment these lines and/or make a new test when database flavor can be detected.
-        # The resultset for BETWEEN queries can differ from database to database.
-
-        # result13 = self.sess.query(DataObject.name).filter(
-        #    Collection.name == self.coll_path).filter(
-        #    Between(DataObject.name, [self.case_sensitive_obj_name1,
-        #                              self.case_sensitive_obj_name1 + "_"])).all()
-        # self.assertTrue(result13.has_value(self.case_sensitive_obj_name1))
-        # self.assertEqual(len(result13), 1)
-
-        # result14 = self.sess.query(DataObject.name).filter(
-        #    Collection.name == self.coll_path).filter(
-        #    Between(DataObject.name, [str.lower(self.case_sensitive_obj_name1),
-        #                              str.lower(self.case_sensitive_obj_name1) + "_"])).all()
-        # self.assertEqual(len(result14), 0)
-
-        # result15 = self.sess.query(DataObject.name).filter(
-        #    Collection.name == self.coll_path).filter(
-        #    Between(DataObject.name, [str.upper(self.case_sensitive_obj_name1),
-        #                              str.upper(self.case_sensitive_obj_name1) + "_"])).all()
-        # self.assertEqual(len(result15), 0)
-
     def test_files_query_case_insensitive(self):
         # This tests that GenQueries are case-insensitive when the case_sensitive
         # option is set to false.


### PR DESCRIPTION
Tests using the  `BETWEEN` operator  are now skipped if they are predicated on being case sensitive and if the  installed object catalog ignores alphabetic case for query conditions dependent on lexical order (as tested by `BETWEEN`, `>`, `>=`, `<`, and `<=`.)